### PR TITLE
Add build scripts and update package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,17 @@
 {
   "name": "glu",
-  "version": "1.0.0",
+  "version": "1.15.0",
   "description": "![Y2K Compliant](https://img.shields.io/badge/Y2K-Compliant-success?style=flat&logo=data:...)",
   "main": "index.js",
   "scripts": {
+    "build": "(\nset -e pipefail\nmuddle\nnpm run build:single\nnpm run build:min\n)",
+    "build:single": "python mini.py src/scripts build/Glu.single.lua --no-minify",
+    "build:min": "python mini.py src/scripts build/Glu.min.lua",
+    "clean": "rm -rf build/Glu.*.lua build/filtered build/tmp",
     "release": "gh workflow run release.yml",
     "docs": "gh workflow run wiki_documentation.yml"
   },
   "keywords": [],
-  "author": "",
-  "license": "ISC"
+  "author": "gesslar",
+  "license": "Unlicense"
 }


### PR DESCRIPTION
Added build scripts and updated package metadata. The PR introduces new npm scripts for building the project, including a main `build` script that runs the build process, along with specific scripts for generating single and minified versions of the Lua files. A `clean` script is also added to remove build artifacts. Additionally, the package version is bumped to 1.15.0, the author is set to "gesslar", and the license is changed from ISC to Unlicense.