### PR TITLE
04 12 correcting glass registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,31 @@
 
 A modular utility library for Mudlet that just works. No fuss, no muss.
 
+## Installation
+
+Glu ships in two forms, depending on how you use it.
+
+### For package authors (recommended)
+
+Bundle `Glu-single.lua` in your package and `require` it. Each package gets
+its own isolated copy — no globals, no version collisions between packages.
+
+```lua
+local glu = require("__PKGNAME__/Glu-single")("__PKGNAME__")
+```
+
+### For personal use
+
+Install the `Glu.mpackage` directly in Mudlet. Glu is available globally
+from the script editor for ad-hoc scripting without needing to manage files.
+
+```lua
+local glu = Glu("MyPackage")
+```
+
 ## Quick Start
 
 ```lua
--- Get some Glu in your life
-local glu = Glu("MyPackage")
-
 -- Iterate over a string? Easy.
 for i, part in glu.string.walk("hello world") do
   if math.random() > 0.5 then
@@ -45,8 +64,6 @@ local just_values = glu.table.values(data)         -- {1, 2, 3}
 Want to add your own stuff? Register your own glasses on a Glu instance:
 
 ```lua
-local glu = Glu("MyPackage")
-
 glu.register({
   name = "awesome",
   class_name = "AwesomeClass",

--- a/README.md
+++ b/README.md
@@ -42,10 +42,12 @@ local just_values = glu.table.values(data)         -- {1, 2, 3}
 
 ## Extend It
 
-Want to add your own stuff? Glu's got you covered:
+Want to add your own stuff? Register your own glasses on a Glu instance:
 
 ```lua
-Glu.glass.register({
+local glu = Glu("MyPackage")
+
+glu.register({
   name = "awesome",
   class_name = "AwesomeClass",
   setup = function(___, self)

--- a/mfile
+++ b/mfile
@@ -1,7 +1,7 @@
 {
   "package": "Glu",
   "title": "Utility functions for Lua",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "author": "gesslar",
   "icon": "liquid-glue.png",
   "dependencies": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glu",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "![Y2K Compliant](https://img.shields.io/badge/Y2K-Compliant-success?style=flat&logo=data:...)",
   "main": "index.js",
   "scripts": {

--- a/src/resources/test/glu_spec.lua
+++ b/src/resources/test/glu_spec.lua
@@ -369,6 +369,418 @@ describe("glu core framework", function()
   end)
 
   -- ========================================================================
+  -- instance.register (post-construction registration)
+  -- ========================================================================
+
+  describe("instance.register", function()
+    it("should have a register function on the instance", function()
+      assert.are.equal("function", type(g.register))
+    end)
+
+    it("should register and instantiate a simple glass", function()
+      g.register({
+        name = "post_reg_simple",
+        class_name = "PostRegSimpleClass",
+        dependencies = {},
+        setup = function(___, self)
+          function self.greet(name)
+            return "hello " .. name
+          end
+        end
+      })
+
+      assert.is_truthy(g.post_reg_simple)
+      assert.are.equal("hello world", g.post_reg_simple.greet("world"))
+    end)
+
+    it("should return the registered glass class", function()
+      local glass = g.register({
+        name = "post_reg_returns",
+        class_name = "PostRegReturnsClass",
+        dependencies = {},
+        setup = function(___, self) end
+      })
+
+      assert.is_truthy(glass)
+      assert.are.equal("post_reg_returns", glass.name)
+      assert.are.equal("PostRegReturnsClass", glass.class_name)
+    end)
+
+    it("should make the glass available via has_object", function()
+      g.register({
+        name = "post_reg_has_obj",
+        class_name = "PostRegHasObjClass",
+        dependencies = {},
+        setup = function(___, self) end
+      })
+
+      assert.is_true(g.has_object("post_reg_has_obj"))
+    end)
+
+    it("should make the glass available via get_object", function()
+      g.register({
+        name = "post_reg_get_obj",
+        class_name = "PostRegGetObjClass",
+        dependencies = {},
+        setup = function(___, self) end
+      })
+
+      local obj = g.get_object("post_reg_get_obj")
+      assert.is_truthy(obj)
+    end)
+
+    it("should also register in the global glass registry", function()
+      g.register({
+        name = "post_reg_global",
+        class_name = "PostRegGlobalClass",
+        dependencies = {},
+        setup = function(___, self) end
+      })
+
+      assert.is_true(Glu.has_glass("post_reg_global"))
+    end)
+
+    it("should give the glass access to the glu instance via ___", function()
+      g.register({
+        name = "post_reg_glu_access",
+        class_name = "PostRegGluAccessClass",
+        dependencies = {},
+        setup = function(___, self)
+          function self.get_package_name()
+            return ___.getPackageName()
+          end
+        end
+      })
+
+      assert.are.equal("Glu", g.post_reg_glu_access.get_package_name())
+    end)
+
+    it("should resolve dependencies on existing glasses", function()
+      g.register({
+        name = "post_reg_with_deps",
+        class_name = "PostRegWithDepsClass",
+        dependencies = { "table" },
+        setup = function(___, self)
+          function self.get_values(t)
+            return ___.table.values(t)
+          end
+        end
+      })
+
+      local vals = g.post_reg_with_deps.get_values({ a = 1, b = 2 })
+      assert.are.equal(2, #vals)
+    end)
+
+    it("should support callable glasses via call option", function()
+      g.register({
+        name = "post_reg_callable",
+        class_name = "PostRegCallableClass",
+        dependencies = {},
+        call = "create",
+        setup = function(___, self)
+          function self.create(value)
+            return { value = value, doubled = value * 2 }
+          end
+        end
+      })
+
+      local result = g.post_reg_callable(21)
+      assert.are.equal(21, result.value)
+      assert.are.equal(42, result.doubled)
+    end)
+
+    it("should not re-register an already registered glass", function()
+      local first = g.register({
+        name = "post_reg_idempotent",
+        class_name = "PostRegIdempotentClass",
+        dependencies = {},
+        setup = function(___, self)
+          self.marker = "first"
+        end
+      })
+
+      local second = g.register({
+        name = "post_reg_idempotent",
+        class_name = "PostRegIdempotentClass",
+        dependencies = {},
+        setup = function(___, self)
+          self.marker = "second"
+        end
+      })
+
+      assert.are.equal(first, second)
+    end)
+
+    it("should error on missing name", function()
+      assert.has_error(function()
+        g.register({
+          class_name = "NoNameClass",
+          setup = function() end
+        })
+      end)
+    end)
+
+    it("should error on missing class_name", function()
+      assert.has_error(function()
+        g.register({
+          name = "post_reg_no_class",
+          setup = function() end
+        })
+      end)
+    end)
+
+    it("should error on missing setup", function()
+      assert.has_error(function()
+        g.register({
+          name = "post_reg_no_setup",
+          class_name = "NoSetupClass"
+        })
+      end)
+    end)
+
+    it("should error on non-table opts", function()
+      assert.has_error(function()
+        g.register("not a table")
+      end)
+    end)
+
+    it("should support valid function for custom validators", function()
+      g.register({
+        name = "post_reg_valid",
+        class_name = "PostRegValidClass",
+        dependencies = {},
+        setup = function(___, self) end,
+        valid = function(___, self)
+          return {
+            is_positive = function(value, argument_index)
+              assert(type(value) == "number" and value > 0,
+                "value must be a positive number for argument " .. argument_index)
+            end
+          }
+        end
+      })
+
+      assert.is_truthy(g.v.is_positive)
+      assert.has_no.errors(function()
+        g.v.is_positive(5, 1)
+      end)
+      assert.has_error(function()
+        g.v.is_positive(-1, 1)
+      end)
+    end)
+  end)
+
+  -- ========================================================================
+  -- instance.register edge cases
+  -- ========================================================================
+
+  describe("instance.register edge cases", function()
+    it("should error when extending an unregistered parent", function()
+      assert.has_error(function()
+        g.register({
+          name = "edge_orphan_child",
+          class_name = "EdgeOrphanChildClass",
+          extends = "edge_nonexistent_parent",
+          dependencies = {},
+          setup = function(___, self) end
+        })
+      end)
+    end)
+
+    it("should support extends when parent is registered post-construction", function()
+      g.register({
+        name = "edge_late_parent",
+        class_name = "EdgeLateParentClass",
+        dependencies = {},
+        setup = function(___, self)
+          function self.parent_method()
+            return "from parent"
+          end
+        end
+      })
+
+      g.register({
+        name = "edge_late_child",
+        class_name = "EdgeLateChildClass",
+        extends = "edge_late_parent",
+        dependencies = {},
+        setup = function(___, self)
+          function self.child_method()
+            return "from child"
+          end
+        end
+      })
+
+      assert.is_truthy(g.edge_late_child)
+      assert.are.equal("from child", g.edge_late_child.child_method())
+      assert.are.equal("from parent", g.edge_late_child.parent_method())
+    end)
+
+    it("should error when dependency does not exist", function()
+      assert.has_error(function()
+        g.register({
+          name = "edge_bad_dep",
+          class_name = "EdgeBadDepClass",
+          dependencies = { "totally_nonexistent_module" },
+          setup = function(___, self) end
+        })
+      end)
+    end)
+
+    it("should error when adopting from a non-existent class", function()
+      assert.has_error(function()
+        g.register({
+          name = "edge_bad_adopt",
+          class_name = "EdgeBadAdoptClass",
+          dependencies = {},
+          adopts = {
+            nonexistent_class = {
+              methods = { "some_method" }
+            }
+          },
+          setup = function(___, self) end
+        })
+      end)
+    end)
+
+    it("should not clobber state when registering same glass twice", function()
+      g.register({
+        name = "edge_double_reg",
+        class_name = "EdgeDoubleRegClass",
+        dependencies = {},
+        setup = function(___, self)
+          self.counter = (self.counter or 0) + 1
+          function self.get_counter()
+            return self.counter
+          end
+        end
+      })
+
+      local first_counter = g.edge_double_reg.get_counter()
+
+      -- Register again with same name - should be idempotent
+      g.register({
+        name = "edge_double_reg",
+        class_name = "EdgeDoubleRegClass",
+        dependencies = {},
+        setup = function(___, self)
+          self.counter = 999
+        end
+      })
+
+      -- Counter should not have changed
+      assert.are.equal(first_counter, g.edge_double_reg.get_counter())
+    end)
+
+    it("should make post-registered glass available to a new instance", function()
+      -- Register on g first
+      g.register({
+        name = "edge_cross_instance",
+        class_name = "EdgeCrossInstanceClass",
+        dependencies = {},
+        setup = function(___, self)
+          function self.ping()
+            return "pong"
+          end
+        end
+      })
+
+      -- New instance should have it since it's now in registeredGlasses
+      local g2 = Glu("Glu")
+      assert.is_truthy(g2.edge_cross_instance)
+      assert.are.equal("pong", g2.edge_cross_instance.ping())
+    end)
+
+    it("should support a post-registered glass using another post-registered glass", function()
+      g.register({
+        name = "edge_provider",
+        class_name = "EdgeProviderClass",
+        dependencies = {},
+        setup = function(___, self)
+          function self.get_value()
+            return 42
+          end
+        end
+      })
+
+      g.register({
+        name = "edge_consumer",
+        class_name = "EdgeConsumerClass",
+        dependencies = { "edge_provider" },
+        setup = function(___, self)
+          function self.get_doubled()
+            return ___.edge_provider.get_value() * 2
+          end
+        end
+      })
+
+      assert.are.equal(84, g.edge_consumer.get_doubled())
+    end)
+
+    it("should support callable glass that returns complex objects", function()
+      g.register({
+        name = "edge_factory",
+        class_name = "EdgeFactoryClass",
+        dependencies = {},
+        call = "create",
+        setup = function(___, self)
+          function self.create(name, value)
+            local obj = { name = name, value = value }
+            function obj.describe()
+              return obj.name .. "=" .. tostring(obj.value)
+            end
+            return obj
+          end
+        end
+      })
+
+      local thing = g.edge_factory("foo", 123)
+      assert.are.equal("foo=123", thing.describe())
+
+      -- Factory itself is still there
+      local thing2 = g.edge_factory("bar", 456)
+      assert.are.equal("bar=456", thing2.describe())
+    end)
+
+    it("should support extends on an already-instantiated built-in glass", function()
+      g.register({
+        name = "edge_extends_builtin",
+        class_name = "EdgeExtendsBuiltinClass",
+        extends = "queue",
+        dependencies = {},
+        setup = function(___, self)
+          function self.custom_method()
+            return "extended"
+          end
+        end
+      })
+
+      assert.is_truthy(g.edge_extends_builtin)
+      assert.are.equal("extended", g.edge_extends_builtin.custom_method())
+      -- Should have parent's methods via __index
+      assert.is_truthy(g.edge_extends_builtin.push)
+    end)
+
+    it("should support adopts from an existing glass", function()
+      g.register({
+        name = "edge_adopter",
+        class_name = "EdgeAdopterClass",
+        dependencies = {},
+        adopts = {
+          string = {
+            methods = { "trim" }
+          }
+        },
+        setup = function(___, self) end
+      })
+
+      assert.is_truthy(g.edge_adopter)
+      assert.is_truthy(g.edge_adopter.trim)
+      assert.are.equal("hello", g.edge_adopter.trim("  hello  "))
+    end)
+  end)
+
+  -- ========================================================================
   -- handler_name (uninstall event)
   -- ========================================================================
 

--- a/src/scripts/glu.lua
+++ b/src/scripts/glu.lua
@@ -8,6 +8,15 @@ if not _G["Glu"] then
 
   local registeredGlasses = {}
 
+  local function unregisterGlass(name)
+    for i, glass in ipairs(registeredGlasses) do
+      if glass.name == name then
+        table.remove(registeredGlasses, i)
+        return
+      end
+    end
+  end
+
   function Glu.get_glasses() return registeredGlasses end
 
   function Glu.get_glass_names()
@@ -97,9 +106,11 @@ if not _G["Glu"] then
 
         if not parent then
           local parent_class = Glu.get_glass(parent_name)
+          if not parent_class then
+            error("Parent class `" .. parent_name .. "` not found for `" .. glu_class.name .. "`")
+          end
           -- Recursively instantiate the parent class
           instantiate(glu, parent_class, ops, into)
-          -- error("Parent class `" .. glu_class.extends .. "` not found for `" .. glu_class.name .. "`")
         end
       end
 
@@ -288,6 +299,24 @@ if not _G["Glu"] then
     -- Let's now create them!
     for _, class in ipairs(registeredGlasses) do
       new_object(instance, class, {}, instance)
+    end
+
+    --- Register a glass on this instance after construction.
+    --- Delegates to Glu.glass.register and then instantiates the
+    --- glass on this instance so it is immediately available.
+    --- @param class_opts table Glass registration options (same as Glu.glass.register)
+    --- @return table The registered glass class
+    function instance.register(class_opts)
+      local is_new = not Glu.has_glass(class_opts.name)
+      local glass = Glu.glass.register(class_opts)
+      local ok, err = pcall(new_object, instance, glass, {}, instance)
+      if not ok then
+        if is_new then
+          unregisterGlass(class_opts.name)
+        end
+        error(err)
+      end
+      return glass
     end
 
     -- Trap events for uninstalling the package and clean ourselves up.

--- a/unify.py
+++ b/unify.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+import re
 import json
 import argparse
 from pathlib import Path
@@ -55,6 +56,20 @@ class GluUnifier:
             with open(script_path, 'r', encoding='utf-8') as f:
                 content = f.read()
                 total_size += len(content)
+
+            # For single-file distribution, make Glu local to the chunk
+            # so each package gets its own isolated copy via require().
+            # Strip the global guard and its closing end.
+            if script_name == 'glu.lua':
+                content = re.sub(
+                    r'^if not _G\["Glu"\] then\n',
+                    'local Glu\n',
+                    content,
+                    count=1,
+                    flags=re.MULTILINE,
+                )
+                # Remove the final `end` that closes the guard
+                content = re.sub(r'\nend\s*$', '', content)
 
             # Add a comment to mark the start of each file
             processed_content.append(f"\n-- File: {script_name}")


### PR DESCRIPTION
- **correcting glass registration**
- **04-12-correcting_glass_registration: 2026-04-12 23:49 - quick save**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `instance.register` — a post-construction API for registering new glasses on a live Glu instance — along with rollback logic via a new `unregisterGlass` helper, a matching test suite (~400 lines of specs), a fix for the previously silenced parent-not-found error, a `unify.py` transform that strips the global guard for single-file distribution, and updated README installation docs.

- **`glu.lua`**: `instance.register` correctly delegates to `Glu.glass.register`, wraps `new_object` in a `pcall`, and rolls back the global registry entry if instantiation fails on a newly-registered glass. The previously commented-out error for a missing parent class is now properly raised.
- **`unify.py`**: The two-step regex transformation (replace the `if not _G[\"Glu\"] then` guard with `local Glu`, then strip the closing `end`) is correct for the current file structure.
- **Tests**: Edge cases for extends, adopts, bad deps, idempotency, cross-instance availability, and callable glasses are all covered.
- **Minor**: `instance.register` accesses `class_opts.name` before validating that `class_opts` is a table; passing a non-table produces an opaque Lua indexing error rather than the descriptive assertion from `Glu.glass.register`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new instance.register feature is well-tested and the single non-blocking P2 is a cosmetic error-message improvement.

The core logic (registration, rollback, cross-instance propagation, error propagation) is correct and thoroughly covered by the new test suite. The one flagged issue (input validation ordering) is a minor UX concern that does not affect correctness — the tests already assert that an error is raised, and Lua will indeed raise one regardless.

No files require special attention.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fscripts%2Fglu.lua%3A309-310%0A**Input%20validation%20order%20exposes%20raw%20Lua%20error**%0A%0A%60class_opts.name%60%20is%20accessed%20on%20line%20310%20before%20%60Glu.glass.register%60%20can%20validate%20that%20%60class_opts%60%20is%20a%20table.%20If%20a%20caller%20passes%20a%20non-table%20value%20%28e.g.%20%60nil%60%20or%20a%20string%29%2C%20Lua%20will%20throw%20a%20generic%20error%20like%20%60%22attempt%20to%20index%20a%20nil%20value%20%28local%20'class_opts'%29%22%60%20instead%20of%20the%20friendly%20%60%22opts%20must%20be%20a%20table%22%60%20assertion%20that%20lives%20inside%20%60Glu.glass.register%60.%0A%0AMoving%20the%20nil%2Ftype%20guard%20to%20the%20top%20of%20%60instance.register%60%20fixes%20this%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20function%20instance.register%28class_opts%29%0A%20%20%20%20%20%20assert%28type%28class_opts%29%20%3D%3D%20%22table%22%2C%20%22opts%20must%20be%20a%20table%22%29%0A%20%20%20%20%20%20local%20is_new%20%3D%20not%20Glu.has_glass%28class_opts.name%29%0A%60%60%60%0A%0A&repo=gesslar%2Fglu"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["04-12-correcting\_glass\_registration: 202..."](https://github.com/gesslar/glu/commit/87dba2360c065943a0bba9d37db20a6092be9674) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28163492)</sub>

<!-- /greptile_comment -->