### PR TITLE
adding build artefacts to releases

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -12,3 +12,24 @@ jobs:
     secrets: inherit
     permissions:
       contents: write
+
+  Bundle:
+    needs: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+      - run: npm ci
+      - name: Build single + minified
+        run: npm run build
+      - name: Attach to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version=$(jq -r '.version' mfile)
+          gh release upload --clobber \
+            "$version" build/Glu-min.lua build/Glu-single.lua

--- a/mfile
+++ b/mfile
@@ -1,7 +1,7 @@
 {
   "package": "Glu",
   "title": "Lua class library for Mudlet",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "gesslar",
   "icon": "liquid-glue.png",
   "dependencies": "",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glu",
-  "version": "2.0.0",
-  "description": "![Y2K Compliant](https://img.shields.io/badge/Y2K-Compliant-success?style=flat&logo=data:...)",
+  "version": "2.0.1",
+  "description": "A modular utility library for Mudlet that just works. No fuss, no muss.",
   "scripts": {
     "build": "(\nset -e pipefail\nnpx @gesslar/muddy\nnpm run build:single\nnpm run build:min\n)",
     "build:single": "python unify.py src/scripts build/Glu-single.lua",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `Bundle` job to the Release workflow that builds single and minified Lua artifacts and attaches them to the GitHub release, alongside version bumps from 2.0.0 to 2.0.1 in both `mfile` and `package.json`.

- The new `Bundle` job correctly gates on `needs: Release`, so it is skipped on unmerged PR closes; it reads the release tag from `mfile` via `jq`, matching the existing plain-version tag convention (e.g. `2.0.1`), and uploads with `--clobber` for safe retries.
- `mfile` and `package.json` are kept in sync at `2.0.1`; the `package.json` description is also cleaned up.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new Bundle job is well-gated, the version tag convention matches existing releases, and retry safety is covered by --clobber.

The workflow addition is straightforward: it depends on the Release job (so it is automatically skipped for non-merged closes), reads the version from mfile using the same plain-version format as existing tags, and uploads with --clobber. No logic errors or missing guards were found.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["adding build artefacts to releases"](https://github.com/gesslar/glu/commit/1b30a3078565b486713f2227fcd5b46dfa00cbaf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38871660)</sub>

<!-- /greptile_comment -->