### PR TITLE
adding luadocs

### DIFF
--- a/src/scripts/colour.lua
+++ b/src/scripts/colour.lua
@@ -18,16 +18,16 @@ local ColourClass = Glu.glass.register({
     --- - ease_in
     --- - ease_out
     ---
-    --- @example
+    ---@example
     --- ```lua
     --- colour.interpolate({255, 0, 0}, {0, 0, 255}, 50)
     --- -- {127, 0, 127}
     --- ```
-    --- @param rgb1 table - The first RGB colour as a table with three elements: red, green, and blue.
-    --- @param rgb2 table - The second RGB colour as a table with three elements: red, green, and blue.
-    --- @param factor number - The step value between 0 and 1.
-    --- @param method string - The interpolation method to use. (Optional, defaults to "smooth")
-    --- @return table - The interpolated RGB colour as a table with three elements: red, green, and blue.
+    ---@param rgb1 table The first RGB colour as a table with three elements: red, green, and blue.
+    ---@param rgb2 table The second RGB colour as a table with three elements: red, green, and blue.
+    ---@param factor number The step value between 0 and 1.
+    ---@param method string The interpolation method to use. (Optional, defaults to "smooth")
+    ---@returns table The interpolated RGB colour as a table with three elements: red, green, and blue.
     function self.interpolate(rgb1, rgb2, factor, method)
       ___.v.rgb_table(rgb1, 1, false)
       ___.v.rgb_table(rgb2, 2, false)
@@ -73,6 +73,15 @@ local ColourClass = Glu.glass.register({
       return self.hsl_to_rgb({ h, s, l })
     end
 
+    --- Converts an RGB colour to HSL.
+    --- Returns hue in degrees (0-360) and saturation and lightness as percentages (0-100).
+    ---
+    ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
+    ---@returns table The HSL colour as a table with three elements: hue, saturation, and lightness.
+    ---@example
+    --- ```lua
+    --- colour.rgb_to_hsl({255, 0, 0})
+    --- ```
     function self.rgb_to_hsl(rgb)
       ___.v.rgb_table(rgb, 1, false)
 
@@ -104,11 +113,11 @@ local ColourClass = Glu.glass.register({
     end
 
     --- Converts an RGB colour to a hex string.
-    --- @param rgb table - The RGB colour as a table with three elements: red, green, and blue.
-    --- @param background table - An optional background RGB colour as a table with three elements: red, green, and blue.
-    --- @return string - The hex string.
+    ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
+    ---@param background table An optional background RGB colour as a table with three elements: red, green, and blue.
+    ---@returns string The hex string.
     ---
-    --- @example
+    ---@example
     --- ```lua
     --- colour.to_hex({255, 255, 255})
     --- -- "#ffffff"
@@ -135,10 +144,10 @@ local ColourClass = Glu.glass.register({
     end
 
     --- Converts an HSL colour to an RGB colour.
-    --- @param hsl table - The HSL colour as a table with three elements: hue, saturation, and lightness.
-    --- @return table - The RGB colour as a table with three elements: red, green, and blue.
+    ---@param hsl table The HSL colour as a table with three elements: hue, saturation, and lightness.
+    ---@returns table The RGB colour as a table with three elements: red, green, and blue.
     ---
-    --- @example
+    ---@example
     --- ```lua
     --- colour.hsl_to_rgb({180, 50, 50})
     --- -- {127, 127, 127}
@@ -179,10 +188,10 @@ local ColourClass = Glu.glass.register({
     end
 
     --- Determines if a colour is a light colour.
-    --- @param rgb table - The RGB colour as a table with three elements: red, green, and blue.
-    --- @return boolean - True if the colour is light, false otherwise.
+    ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
+    ---@returns boolean True if the colour is light, false otherwise.
     ---
-    --- @example
+    ---@example
     --- ```lua
     --- colour.is_light({255, 255, 255})
     --- -- true
@@ -198,10 +207,10 @@ local ColourClass = Glu.glass.register({
     end
 
     --- Lightens or darkens a colour by a given amount.
-    --- @param rgb table - The RGB colour as a table with three elements: red, green, and blue.
-    --- @param amount number - The amount to adjust the colour by.
-    --- @param lighten boolean - Whether to lighten (true) or darken (false) the colour.
-    --- @return table - The adjusted RGB colour as a table with three elements: red, green, and blue.
+    ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
+    ---@param amount number The amount to adjust the colour by.
+    ---@param lighten boolean Whether to lighten (true) or darken (false) the colour.
+    ---@returns table The adjusted RGB colour as a table with three elements: red, green, and blue.
     function self.adjust_colour(rgb, amount, lighten)
       ___.v.rgb_table(rgb, 1, false)
       ___.v.type(amount, "number", 2, true)
@@ -218,11 +227,11 @@ local ColourClass = Glu.glass.register({
     end
 
     --- Lightens a colour by a given amount.
-    --- @param rgb table - The RGB colour as a table with three elements: red, green, and blue.
-    --- @param amount number - The amount to lighten the colour by. (Optional, defaults to 30)
-    --- @return table - The lightened RGB colour as a table with three elements: red, green, and blue.
+    ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
+    ---@param amount number The amount to lighten the colour by. (Optional, defaults to 30)
+    ---@returns table The lightened RGB colour as a table with three elements: red, green, and blue.
     ---
-    --- @example
+    ---@example
     --- ```lua
     --- colour.lighten({100,100,100},50)
     --- -- {150, 150, 150}
@@ -233,11 +242,11 @@ local ColourClass = Glu.glass.register({
 
     --- Darkens a colour by a given amount.
     ---
-    --- @param rgb table - The RGB colour as a table with three elements: red, green, and blue.
-    --- @param amount number - The amount to darken the colour by. (Optional, defaults to 30)
-    --- @return table - The darkened RGB colour as a table with three elements: red, green, and blue.
+    ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
+    ---@param amount number The amount to darken the colour by. (Optional, defaults to 30)
+    ---@returns table The darkened RGB colour as a table with three elements: red, green, and blue.
     ---
-    --- @example
+    ---@example
     --- ```lua
     --- colour.darken({100,100,100},50)
     --- -- {50, 50, 50}
@@ -248,12 +257,12 @@ local ColourClass = Glu.glass.register({
 
     --- Lightens or darkens the first colour by a given amount based on a comparison with the second colour.
     --- If the colours are already contrasting, the original colour is returned.
-    --- @param rgb_colour table - The RGB colour to adjust, as a table with three elements: red, green, and blue.
-    --- @param rgb_compare table - The RGB colour to compare against, as a table with three elements: red, green, and blue.
-    --- @param amount number - The amount to lighten or darken the colour by. (Optional, defaults to 85)
-    --- @return table - The adjusted RGB colour as a table with three elements: red, green, and blue. Unless the colours are already constrasted, in which case the original colour is returned.
+    ---@param rgb_colour table The RGB colour to adjust, as a table with three elements: red, green, and blue.
+    ---@param rgb_compare table The RGB colour to compare against, as a table with three elements: red, green, and blue.
+    ---@param amount number The amount to lighten or darken the colour by. (Optional, defaults to 85)
+    ---@returns table The adjusted RGB colour as a table with three elements: red, green, and blue. Unless the colours are already constrasted, in which case the original colour is returned.
     ---
-    --- @example
+    ---@example
     --- ```lua
     --- colour.lighten_or_darken({100,100,100}, {255,255,255}, 50)
     --- -- {100, 100, 100}
@@ -282,13 +291,13 @@ local ColourClass = Glu.glass.register({
     end
 
     --- Returns the complementary colour of a given colour.
-    --- @example
+    ---@example
     --- ```lua
     --- colour.complementary({ 150, 150, 150 })
     --- -- { 105, 105, 105 }
     --- ```
-    --- @param rgb table - The RGB colour as a table with three elements: red, green, and blue.
-    --- @return table - The complementary RGB colour as a table with three elements: red, green, and blue.
+    ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
+    ---@returns table The complementary RGB colour as a table with three elements: red, green, and blue.
     function self.complementary(rgb)
       ___.v.rgb_table(rgb, 1, false)
 
@@ -300,13 +309,13 @@ local ColourClass = Glu.glass.register({
     end
 
     --- Converts a colour to its grayscale equivalent.
-    --- @example
+    ---@example
     --- ```lua
     --- colour.grayscale({ 35, 50, 100 })
     --- -- { 62, 62, 62 }
     --- ```
-    --- @param rgb table - The RGB colour as a table with three elements: red, green, and blue.
-    --- @return table - The grayscale RGB colour as a table with three elements: red, green, and blue.
+    ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
+    ---@returns table The grayscale RGB colour as a table with three elements: red, green, and blue.
     function self.grayscale(rgb)
       ___.v.rgb_table(rgb, 1, false)
 
@@ -315,14 +324,14 @@ local ColourClass = Glu.glass.register({
     end
 
     --- Adjusts the saturation of a colour by a given factor.
-    --- @example
+    ---@example
     --- ```lua
     --- colour.adjust_saturation({ 35, 50, 100 }, 0.5)
     --- -- { 48, 55, 80 }
     --- ```
-    --- @param rgb table - The RGB colour as a table with three elements: red, green, and blue.
-    --- @param factor number - A factor between 0 (fully desaturated) and 1 (fully saturated).
-    --- @return table - The adjusted RGB colour as a table with three elements: red, green, and blue.
+    ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
+    ---@param factor number A factor between 0 (fully desaturated) and 1 (fully saturated).
+    ---@returns table The adjusted RGB colour as a table with three elements: red, green, and blue.
     function self.adjust_saturation(rgb, factor)
       ___.v.rgb_table(rgb, 1, false)
       ___.v.type(factor, "number", 2, true)
@@ -337,25 +346,25 @@ local ColourClass = Glu.glass.register({
     end
 
     --- Generates a random RGB colour.
-    --- @example
+    ---@example
     --- ```lua
     --- colour.random()
     --- -- { 123, 45, 67 }
     --- ```
-    --- @return table - A random RGB colour as a table with three elements: red, green, and blue.
+    ---@returns table A random RGB colour as a table with three elements: red, green, and blue.
     function self.random()
       return { math.random(0, 255), math.random(0, 255), math.random(0, 255) }
     end
 
     --- Generates a random shade of a given colour within a range.
-    --- @example
+    ---@example
     --- ```lua
     --- colour.random_shade({ 100, 100, 100 }, 50)
     --- -- { 150, 150, 150 }
     --- ```
-    --- @param rgb table - The RGB colour as a table with three elements: red, green, and blue.
-    --- @param range number - The range to adjust the colour by (e.g., 50 means +/- 50 for R, G, and B). (Optional, defaults to 50)
-    --- @return table - A random RGB colour that is a shade of the given colour.
+    ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
+    ---@param range number The range to adjust the colour by (e.g., 50 means +/- 50 for R, G, and B). (Optional, defaults to 50)
+    ---@returns table A random RGB colour that is a shade of the given colour.
     function self.random_shade(rgb, range)
       ___.v.rgb_table(rgb, 1, false)
       ___.v.type(range, "number", 2, true)
@@ -371,13 +380,13 @@ local ColourClass = Glu.glass.register({
     --- Generates the triad colours of a given colour. Does not return the
     --- original colour, but two returned colours that are considered tritones of
     --- the original colour.
-    --- @example
+    ---@example
     --- ```lua
     --- colour.triad({ 100, 100, 100 })
     --- -- { { 15, 204, 204 }, { 100, 204, 204 } }
     --- ```
-    --- @param rgb table - The RGB colour as a table with three elements: red, green, and blue.
-    --- @return table - A table of RGB colours that are the triad of the given colour.
+    ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
+    ---@returns table A table of RGB colours that are the triad of the given colour.
     function self.triad(rgb)
       ___.v.rgb_table(rgb, 1, false)
 
@@ -392,10 +401,10 @@ local ColourClass = Glu.glass.register({
     --- Generates the analogous colours of a given colour.
     --- The analogous colours are generated by rotating the hue of the given
     --- colour by a given angle.
-    --- @param rgb table - The RGB colour as a table with three elements: red, green, and blue.
-    --- @param angle number - The angle to separate the analogous colours by. (Optional, defaults to 30)
-    --- @return table - A table of RGB colours that are analogous to the given colour.
-    --- @example
+    ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
+    ---@param angle number The angle to separate the analogous colours by. (Optional, defaults to 30)
+    ---@returns table A table of RGB colours that are analogous to the given colour.
+    ---@example
     --- ```lua
     --- colour.analogous({ 100, 100, 100 })
     --- -- { { 70, 100, 100 }, { 100, 100, 100 }, { 130, 100, 100 } }
@@ -415,14 +424,14 @@ local ColourClass = Glu.glass.register({
     end
 
     --- Generates the split complement colours of a given colour.
-    --- @example
+    ---@example
     --- ```lua
     --- colour.split_complement({ 100, 100, 100 })
     --- -- { { 15, 204, 204 }, { 100, 204, 204 } }
     --- ```
-    --- @param rgb table - The RGB colour as a table with three elements: red, green, and blue.
-    --- @param angle number - The angle to separate the split complement colours by. (Optional, defaults to 30)
-    --- @return table - A table of RGB colours that are the split complement of the given colour.
+    ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
+    ---@param angle number The angle to separate the split complement colours by. (Optional, defaults to 30)
+    ---@returns table A table of RGB colours that are the split complement of the given colour.
     function self.split_complement(rgb, angle)
       ___.v.rgb_table(rgb, 1, false)
       ___.v.type(angle, "number", 2, true)
@@ -438,14 +447,14 @@ local ColourClass = Glu.glass.register({
     end
 
     --- Generates a series of monochromatic colours based on a given colour.
-    --- @example
+    ---@example
     --- ```lua
     --- colour.monochrome({ 100, 100, 100 })
     --- -- { { 100, 100, 100 }, { 100, 100, 100 }, { 100, 100, 100 } }
     --- ```
-    --- @param rgb table - The RGB colour as a table with three elements: red, green, and blue.
-    --- @param steps number - The number of variations to generate. (Optional, defaults to 5)
-    --- @return table - A table of RGB colours that are monochromatic variations of the given colour.
+    ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
+    ---@param steps number The number of variations to generate. (Optional, defaults to 5)
+    ---@returns table A table of RGB colours that are monochromatic variations of the given colour.
     function self.monochrome(rgb, steps)
       ___.v.rgb_table(rgb, 1, false)
       ___.v.type(steps, "number", 2, true)
@@ -465,13 +474,13 @@ local ColourClass = Glu.glass.register({
     end
 
     --- Generates the tetrad colours of a given colour.
-    --- @example
+    ---@example
     --- ```lua
     --- colour.tetrad({ 100, 100, 100 })
     --- -- { { 100, 100, 100 }, { 100, 100, 100 }, { 100, 100, 100 }, { 100, 100, 100 } }
     --- ```
-    --- @param rgb table - The RGB colour as a table with three elements: red, green, and blue.
-    --- @return table - A table of RGB colours that are the tetrad of the given colour.
+    ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
+    ---@returns table A table of RGB colours that are the tetrad of the given colour.
     function self.tetrad(rgb)
       ___.v.rgb_table(rgb, 1, false)
 
@@ -485,14 +494,14 @@ local ColourClass = Glu.glass.register({
     end
 
     --- Calculates the contrast ratio between two colours.
-    --- @example
+    ---@example
     --- ```lua
     --- colour.contrast_ratio({ 100, 100, 100 }, { 0, 0, 0 })
     --- -- 12.0
     --- ```
-    --- @param rgb1 table - The first RGB colour as a table with three elements: red, green, and blue.
-    --- @param rgb2 table - The second RGB colour as a table with three elements: red, green, and blue.
-    --- @return number - The contrast ratio between the two colours.
+    ---@param rgb1 table The first RGB colour as a table with three elements: red, green, and blue.
+    ---@param rgb2 table The second RGB colour as a table with three elements: red, green, and blue.
+    ---@returns number The contrast ratio between the two colours.
     function self.contrast_ratio(rgb1, rgb2)
       ___.v.rgb_table(rgb1, 1, false)
       ___.v.rgb_table(rgb2, 2, false)
@@ -517,13 +526,13 @@ local ColourClass = Glu.glass.register({
     end
 
     --- Calculates the contrasting colour based on the luminance of a given colour.
-    --- @example
+    ---@example
     --- ```lua
     --- colour.contrast({ 100, 100, 100 })
     --- -- { 0, 0, 0 }
     --- ```
-    --- @param rgb table - The RGB colour as a table with three elements: red, green, and blue.
-    --- @return table - The contrasting colour as a table with three elements: red, green, and blue.
+    ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
+    ---@returns table The contrasting colour as a table with three elements: red, green, and blue.
     function self.contrast(rgb)
       ___.v.rgb_table(rgb, 1, false)
 

--- a/src/scripts/colour.lua
+++ b/src/scripts/colour.lua
@@ -27,7 +27,7 @@ local ColourClass = Glu.glass.register({
     ---@param rgb2 table The second RGB colour as a table with three elements: red, green, and blue.
     ---@param factor number The step value between 0 and 1.
     ---@param method string The interpolation method to use. (Optional, defaults to "smooth")
-    ---@returns table The interpolated RGB colour as a table with three elements: red, green, and blue.
+    ---@return table rgb The interpolated RGB colour as a table with three elements: red, green, and blue.
     function self.interpolate(rgb1, rgb2, factor, method)
       ___.v.rgb_table(rgb1, 1, false)
       ___.v.rgb_table(rgb2, 2, false)
@@ -77,7 +77,7 @@ local ColourClass = Glu.glass.register({
     --- Returns hue in degrees (0-360) and saturation and lightness as percentages (0-100).
     ---
     ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
-    ---@returns table The HSL colour as a table with three elements: hue, saturation, and lightness.
+    ---@return table hsl The HSL colour as a table with three elements: hue, saturation, and lightness.
     ---@example
     --- ```lua
     --- colour.rgb_to_hsl({255, 0, 0})
@@ -115,7 +115,7 @@ local ColourClass = Glu.glass.register({
     --- Converts an RGB colour to a hex string.
     ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
     ---@param background table An optional background RGB colour as a table with three elements: red, green, and blue.
-    ---@returns string The hex string.
+    ---@return string hex The hex string.
     ---
     ---@example
     --- ```lua
@@ -145,7 +145,7 @@ local ColourClass = Glu.glass.register({
 
     --- Converts an HSL colour to an RGB colour.
     ---@param hsl table The HSL colour as a table with three elements: hue, saturation, and lightness.
-    ---@returns table The RGB colour as a table with three elements: red, green, and blue.
+    ---@return table rgb The RGB colour as a table with three elements: red, green, and blue.
     ---
     ---@example
     --- ```lua
@@ -189,7 +189,7 @@ local ColourClass = Glu.glass.register({
 
     --- Determines if a colour is a light colour.
     ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
-    ---@returns boolean True if the colour is light, false otherwise.
+    ---@return boolean is_light True if the colour is light, false otherwise.
     ---
     ---@example
     --- ```lua
@@ -210,7 +210,7 @@ local ColourClass = Glu.glass.register({
     ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
     ---@param amount number The amount to adjust the colour by.
     ---@param lighten boolean Whether to lighten (true) or darken (false) the colour.
-    ---@returns table The adjusted RGB colour as a table with three elements: red, green, and blue.
+    ---@return table rgb The adjusted RGB colour as a table with three elements: red, green, and blue.
     function self.adjust_colour(rgb, amount, lighten)
       ___.v.rgb_table(rgb, 1, false)
       ___.v.type(amount, "number", 2, true)
@@ -229,7 +229,7 @@ local ColourClass = Glu.glass.register({
     --- Lightens a colour by a given amount.
     ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
     ---@param amount number The amount to lighten the colour by. (Optional, defaults to 30)
-    ---@returns table The lightened RGB colour as a table with three elements: red, green, and blue.
+    ---@return table rgb The lightened RGB colour as a table with three elements: red, green, and blue.
     ---
     ---@example
     --- ```lua
@@ -244,7 +244,7 @@ local ColourClass = Glu.glass.register({
     ---
     ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
     ---@param amount number The amount to darken the colour by. (Optional, defaults to 30)
-    ---@returns table The darkened RGB colour as a table with three elements: red, green, and blue.
+    ---@return table rgb The darkened RGB colour as a table with three elements: red, green, and blue.
     ---
     ---@example
     --- ```lua
@@ -260,7 +260,7 @@ local ColourClass = Glu.glass.register({
     ---@param rgb_colour table The RGB colour to adjust, as a table with three elements: red, green, and blue.
     ---@param rgb_compare table The RGB colour to compare against, as a table with three elements: red, green, and blue.
     ---@param amount number The amount to lighten or darken the colour by. (Optional, defaults to 85)
-    ---@returns table The adjusted RGB colour as a table with three elements: red, green, and blue. Unless the colours are already constrasted, in which case the original colour is returned.
+    ---@return table rgb The adjusted RGB colour as a table with three elements: red, green, and blue. Unless the colours are already constrasted, in which case the original colour is returned.
     ---
     ---@example
     --- ```lua
@@ -297,7 +297,7 @@ local ColourClass = Glu.glass.register({
     --- -- { 105, 105, 105 }
     --- ```
     ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
-    ---@returns table The complementary RGB colour as a table with three elements: red, green, and blue.
+    ---@return table rgb The complementary RGB colour as a table with three elements: red, green, and blue.
     function self.complementary(rgb)
       ___.v.rgb_table(rgb, 1, false)
 
@@ -315,7 +315,7 @@ local ColourClass = Glu.glass.register({
     --- -- { 62, 62, 62 }
     --- ```
     ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
-    ---@returns table The grayscale RGB colour as a table with three elements: red, green, and blue.
+    ---@return table gray The grayscale RGB colour as a table with three elements: red, green, and blue.
     function self.grayscale(rgb)
       ___.v.rgb_table(rgb, 1, false)
 
@@ -331,7 +331,7 @@ local ColourClass = Glu.glass.register({
     --- ```
     ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
     ---@param factor number A factor between 0 (fully desaturated) and 1 (fully saturated).
-    ---@returns table The adjusted RGB colour as a table with three elements: red, green, and blue.
+    ---@return table rgb The adjusted RGB colour as a table with three elements: red, green, and blue.
     function self.adjust_saturation(rgb, factor)
       ___.v.rgb_table(rgb, 1, false)
       ___.v.type(factor, "number", 2, true)
@@ -351,7 +351,7 @@ local ColourClass = Glu.glass.register({
     --- colour.random()
     --- -- { 123, 45, 67 }
     --- ```
-    ---@returns table A random RGB colour as a table with three elements: red, green, and blue.
+    ---@return table rgb A random RGB colour as a table with three elements: red, green, and blue.
     function self.random()
       return { math.random(0, 255), math.random(0, 255), math.random(0, 255) }
     end
@@ -364,7 +364,7 @@ local ColourClass = Glu.glass.register({
     --- ```
     ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
     ---@param range number The range to adjust the colour by (e.g., 50 means +/- 50 for R, G, and B). (Optional, defaults to 50)
-    ---@returns table A random RGB colour that is a shade of the given colour.
+    ---@return table rgb A random RGB colour that is a shade of the given colour.
     function self.random_shade(rgb, range)
       ___.v.rgb_table(rgb, 1, false)
       ___.v.type(range, "number", 2, true)
@@ -386,7 +386,7 @@ local ColourClass = Glu.glass.register({
     --- -- { { 15, 204, 204 }, { 100, 204, 204 } }
     --- ```
     ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
-    ---@returns table A table of RGB colours that are the triad of the given colour.
+    ---@return table triad A table of RGB colours that are the triad of the given colour.
     function self.triad(rgb)
       ___.v.rgb_table(rgb, 1, false)
 
@@ -403,7 +403,7 @@ local ColourClass = Glu.glass.register({
     --- colour by a given angle.
     ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
     ---@param angle number The angle to separate the analogous colours by. (Optional, defaults to 30)
-    ---@returns table A table of RGB colours that are analogous to the given colour.
+    ---@return table analogous A table of RGB colours that are analogous to the given colour.
     ---@example
     --- ```lua
     --- colour.analogous({ 100, 100, 100 })
@@ -431,7 +431,7 @@ local ColourClass = Glu.glass.register({
     --- ```
     ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
     ---@param angle number The angle to separate the split complement colours by. (Optional, defaults to 30)
-    ---@returns table A table of RGB colours that are the split complement of the given colour.
+    ---@return table split_complement A table of RGB colours that are the split complement of the given colour.
     function self.split_complement(rgb, angle)
       ___.v.rgb_table(rgb, 1, false)
       ___.v.type(angle, "number", 2, true)
@@ -454,7 +454,7 @@ local ColourClass = Glu.glass.register({
     --- ```
     ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
     ---@param steps number The number of variations to generate. (Optional, defaults to 5)
-    ---@returns table A table of RGB colours that are monochromatic variations of the given colour.
+    ---@return table results A table of RGB colours that are monochromatic variations of the given colour.
     function self.monochrome(rgb, steps)
       ___.v.rgb_table(rgb, 1, false)
       ___.v.type(steps, "number", 2, true)
@@ -480,7 +480,7 @@ local ColourClass = Glu.glass.register({
     --- -- { { 100, 100, 100 }, { 100, 100, 100 }, { 100, 100, 100 }, { 100, 100, 100 } }
     --- ```
     ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
-    ---@returns table A table of RGB colours that are the tetrad of the given colour.
+    ---@return table tetrad A table of RGB colours that are the tetrad of the given colour.
     function self.tetrad(rgb)
       ___.v.rgb_table(rgb, 1, false)
 
@@ -501,7 +501,7 @@ local ColourClass = Glu.glass.register({
     --- ```
     ---@param rgb1 table The first RGB colour as a table with three elements: red, green, and blue.
     ---@param rgb2 table The second RGB colour as a table with three elements: red, green, and blue.
-    ---@returns number The contrast ratio between the two colours.
+    ---@return number ratio The contrast ratio between the two colours.
     function self.contrast_ratio(rgb1, rgb2)
       ___.v.rgb_table(rgb1, 1, false)
       ___.v.rgb_table(rgb2, 2, false)
@@ -532,7 +532,7 @@ local ColourClass = Glu.glass.register({
     --- -- { 0, 0, 0 }
     --- ```
     ---@param rgb table The RGB colour as a table with three elements: red, green, and blue.
-    ---@returns table The contrasting colour as a table with three elements: red, green, and blue.
+    ---@return table rgb The contrasting colour as a table with three elements: red, green, and blue.
     function self.contrast(rgb)
       ___.v.rgb_table(rgb, 1, false)
 

--- a/src/scripts/conditions.lua
+++ b/src/scripts/conditions.lua
@@ -6,8 +6,8 @@ local ConditionsClass = Glu.glass.register({
     --- Checks if a condition is true or false.
     ---@param condition boolean The condition to check
     ---@param message string|nil The message to return if the condition is false
-    ---@returns boolean The condition
-    ---@returns string|nil The message
+    ---@return boolean ok The condition
+    ---@return string|nil message The message
     function self.is(condition, message)
       assert(type(condition) == "boolean", "Expected a boolean as the first argument")
       assert(type(message) == "string" or message == nil, "Expected a string or nil as the second argument")
@@ -23,8 +23,8 @@ local ConditionsClass = Glu.glass.register({
     --- Checks if a condition is true.
     ---@param condition boolean The condition to check
     ---@param message string|nil The message to return if the condition is false
-    ---@returns boolean The condition
-    ---@returns string|nil The message
+    ---@return boolean ok The condition
+    ---@return string|nil message The message
     function self.is_true(condition, message)
       return self.is(condition, message or "Expected condition to be true")
     end
@@ -32,8 +32,8 @@ local ConditionsClass = Glu.glass.register({
     --- Checks if a condition is false.
     ---@param condition boolean The condition to check
     ---@param message string|nil The message to return if the condition is true
-    ---@returns boolean The condition
-    ---@returns string|nil The message
+    ---@return boolean ok The condition
+    ---@return string|nil message The message
     function self.is_false(condition, message)
       return self.is(not condition, message or "Expected condition to be false")
     end
@@ -41,8 +41,8 @@ local ConditionsClass = Glu.glass.register({
     --- Checks if a value is nil.
     ---@param value any The value to check
     ---@param message string|nil The message to return if the value is not nil
-    ---@returns boolean The condition
-    ---@returns string|nil The message
+    ---@return boolean ok The condition
+    ---@return string|nil message The message
     function self.is_nil(value, message)
       return self.is(value == nil, message or "Expected `{value}` to be nil")
     end
@@ -50,8 +50,8 @@ local ConditionsClass = Glu.glass.register({
     --- Checks if a value is not nil.
     ---@param value any The value to check
     ---@param message string|nil The message to return if the value is nil
-    ---@returns boolean The condition
-    ---@returns string|nil The message
+    ---@return boolean ok The condition
+    ---@return string|nil message The message
     function self.is_not_nil(value, message)
       return self.is(value ~= nil, message or "Expected `{value}` to not be nil")
     end
@@ -60,8 +60,8 @@ local ConditionsClass = Glu.glass.register({
     ---@param func function The function to check
     ---@param message string|nil The message to return if the function does not throw an error
     ---@param check function|nil The function to check the error message against
-    ---@returns boolean The condition
-    ---@returns string|nil The message
+    ---@return boolean ok The condition
+    ---@return string|nil message The message
     function self.is_error(func, message, check)
       assert(type(func) == "function", "Expected a function as the first argument")
       assert(type(message) == "string" or message == nil, "Expected a string or nil as the second argument")
@@ -92,8 +92,8 @@ local ConditionsClass = Glu.glass.register({
     ---@param a any The first value to check
     ---@param b any The second value to check
     ---@param message string|nil The message to return if the values are not equal
-    ---@returns boolean The condition
-    ---@returns string|nil The message
+    ---@return boolean ok The condition
+    ---@return string|nil message The message
     function self.is_eq(a, b, message)
       return self.is(a == b,
         message or f "Expected `{a}` to equal `{b}`\n")
@@ -103,8 +103,8 @@ local ConditionsClass = Glu.glass.register({
     ---@param a any The first value to check
     ---@param b any The second value to check
     ---@param message string|nil The message to return if the values are equal
-    ---@returns boolean The condition
-    ---@returns string|nil The message
+    ---@return boolean ok The condition
+    ---@return string|nil message The message
     function self.is_ne(a, b, message)
       return self.is(a ~= b,
         message or f "Expected `{a}` to not equal `{b}`\n")
@@ -114,8 +114,8 @@ local ConditionsClass = Glu.glass.register({
     ---@param a any The first value to check
     ---@param b any The second value to check
     ---@param message string|nil The message to return if the values are not less than
-    ---@returns boolean The condition
-    ---@returns string|nil The message
+    ---@return boolean ok The condition
+    ---@return string|nil message The message
     function self.is_lt(a, b, message)
       return self.is(a < b,
         message or f "Expected `{a}` to be less than `{b}`\n")
@@ -125,8 +125,8 @@ local ConditionsClass = Glu.glass.register({
     ---@param a any The first value to check
     ---@param b any The second value to check
     ---@param message string|nil The message to return if the values are not less than or equal to
-    ---@returns boolean The condition
-    ---@returns string|nil The message
+    ---@return boolean ok The condition
+    ---@return string|nil message The message
     function self.is_le(a, b, message)
       return self.is(a <= b,
         message or f "Expected `{a}` to be less than or equal to `{b}`\n")
@@ -136,8 +136,8 @@ local ConditionsClass = Glu.glass.register({
     ---@param a any The first value to check
     ---@param b any The second value to check
     ---@param message string|nil The message to return if the values are not greater than
-    ---@returns boolean The condition
-    ---@returns string|nil The message
+    ---@return boolean ok The condition
+    ---@return string|nil message The message
     function self.is_gt(a, b, message)
       return self.is(a > b,
         message or f "Expected `{a}` to be greater than `{b}`\n")
@@ -147,8 +147,8 @@ local ConditionsClass = Glu.glass.register({
     ---@param a any The first value to check
     ---@param b any The second value to check
     ---@param message string|nil The message to return if the values are not greater than or equal to
-    ---@returns boolean The condition
-    ---@returns string|nil The message
+    ---@return boolean ok The condition
+    ---@return string|nil message The message
     function self.is_ge(a, b, message)
       return self.is(a >= b, message or f "Expected `{a}` to be greater than or equal to `{b}`\n")
     end
@@ -157,8 +157,8 @@ local ConditionsClass = Glu.glass.register({
     ---@param value any The value to check
     ---@param type string The type to check against
     ---@param message string|nil The message to return if the values are not of the specified type
-    ---@returns boolean The condition
-    ---@returns string|nil The message
+    ---@return boolean ok The condition
+    ---@return string|nil message The message
     function self.is_type(value, expected_type, message)
       return self.is(type(value) == expected_type, message or f "Expected `{value}` to be of type `{expected_type}`\n")
     end
@@ -167,8 +167,8 @@ local ConditionsClass = Glu.glass.register({
     ---@param a any The first value to check
     ---@param b any The second value to check
     ---@param message string|nil The message to return if the values are not deeply equal
-    ---@returns boolean The condition
-    ---@returns string|nil The message
+    ---@return boolean ok The condition
+    ---@return string|nil message The message
     function self.is_deeply(a, b, message)
       local result, mess
 

--- a/src/scripts/conditions.lua
+++ b/src/scripts/conditions.lua
@@ -4,10 +4,10 @@ local ConditionsClass = Glu.glass.register({
   dependencies = {},
   setup = function(___, self)
     --- Checks if a condition is true or false.
-    --- @param condition boolean - The condition to check
-    --- @param message string|nil - The message to return if the condition is false
-    --- @return boolean - The condition
-    --- @return string|nil - The message
+    ---@param condition boolean The condition to check
+    ---@param message string|nil The message to return if the condition is false
+    ---@returns boolean The condition
+    ---@returns string|nil The message
     function self.is(condition, message)
       assert(type(condition) == "boolean", "Expected a boolean as the first argument")
       assert(type(message) == "string" or message == nil, "Expected a string or nil as the second argument")
@@ -21,47 +21,47 @@ local ConditionsClass = Glu.glass.register({
     end
 
     --- Checks if a condition is true.
-    --- @param condition boolean - The condition to check
-    --- @param message string|nil - The message to return if the condition is false
-    --- @return boolean - The condition
-    --- @return string|nil - The message
+    ---@param condition boolean The condition to check
+    ---@param message string|nil The message to return if the condition is false
+    ---@returns boolean The condition
+    ---@returns string|nil The message
     function self.is_true(condition, message)
       return self.is(condition, message or "Expected condition to be true")
     end
 
     --- Checks if a condition is false.
-    --- @param condition boolean - The condition to check
-    --- @param message string|nil - The message to return if the condition is true
-    --- @return boolean - The condition
-    --- @return string|nil - The message
+    ---@param condition boolean The condition to check
+    ---@param message string|nil The message to return if the condition is true
+    ---@returns boolean The condition
+    ---@returns string|nil The message
     function self.is_false(condition, message)
       return self.is(not condition, message or "Expected condition to be false")
     end
 
     --- Checks if a value is nil.
-    --- @param value any - The value to check
-    --- @param message string|nil - The message to return if the value is not nil
-    --- @return boolean - The condition
-    --- @return string|nil - The message
+    ---@param value any The value to check
+    ---@param message string|nil The message to return if the value is not nil
+    ---@returns boolean The condition
+    ---@returns string|nil The message
     function self.is_nil(value, message)
       return self.is(value == nil, message or "Expected `{value}` to be nil")
     end
 
     --- Checks if a value is not nil.
-    --- @param value any - The value to check
-    --- @param message string|nil - The message to return if the value is nil
-    --- @return boolean - The condition
-    --- @return string|nil - The message
+    ---@param value any The value to check
+    ---@param message string|nil The message to return if the value is nil
+    ---@returns boolean The condition
+    ---@returns string|nil The message
     function self.is_not_nil(value, message)
       return self.is(value ~= nil, message or "Expected `{value}` to not be nil")
     end
 
     --- Checks if a function throws an error.
-    --- @param func function - The function to check
-    --- @param message string|nil - The message to return if the function does not throw an error
-    --- @param check function|nil - The function to check the error message against
-    --- @return boolean - The condition
-    --- @return string|nil - The message
+    ---@param func function The function to check
+    ---@param message string|nil The message to return if the function does not throw an error
+    ---@param check function|nil The function to check the error message against
+    ---@returns boolean The condition
+    ---@returns string|nil The message
     function self.is_error(func, message, check)
       assert(type(func) == "function", "Expected a function as the first argument")
       assert(type(message) == "string" or message == nil, "Expected a string or nil as the second argument")
@@ -89,86 +89,86 @@ local ConditionsClass = Glu.glass.register({
     end
 
     --- Checks if two values are equal.
-    --- @param a any - The first value to check
-    --- @param b any - The second value to check
-    --- @param message string|nil - The message to return if the values are not equal
-    --- @return boolean - The condition
-    --- @return string|nil - The message
+    ---@param a any The first value to check
+    ---@param b any The second value to check
+    ---@param message string|nil The message to return if the values are not equal
+    ---@returns boolean The condition
+    ---@returns string|nil The message
     function self.is_eq(a, b, message)
       return self.is(a == b,
         message or f "Expected `{a}` to equal `{b}`\n")
     end
 
     --- Checks if two values are not equal.
-    --- @param a any - The first value to check
-    --- @param b any - The second value to check
-    --- @param message string|nil - The message to return if the values are equal
-    --- @return boolean - The condition
-    --- @return string|nil - The message
+    ---@param a any The first value to check
+    ---@param b any The second value to check
+    ---@param message string|nil The message to return if the values are equal
+    ---@returns boolean The condition
+    ---@returns string|nil The message
     function self.is_ne(a, b, message)
       return self.is(a ~= b,
         message or f "Expected `{a}` to not equal `{b}`\n")
     end
 
     --- Checks if a value is less than another value.
-    --- @param a any - The first value to check
-    --- @param b any - The second value to check
-    --- @param message string|nil - The message to return if the values are not less than
-    --- @return boolean - The condition
-    --- @return string|nil - The message
+    ---@param a any The first value to check
+    ---@param b any The second value to check
+    ---@param message string|nil The message to return if the values are not less than
+    ---@returns boolean The condition
+    ---@returns string|nil The message
     function self.is_lt(a, b, message)
       return self.is(a < b,
         message or f "Expected `{a}` to be less than `{b}`\n")
     end
 
     --- Checks if a value is less than or equal to another value.
-    --- @param a any - The first value to check
-    --- @param b any - The second value to check
-    --- @param message string|nil - The message to return if the values are not less than or equal to
-    --- @return boolean - The condition
-    --- @return string|nil - The message
+    ---@param a any The first value to check
+    ---@param b any The second value to check
+    ---@param message string|nil The message to return if the values are not less than or equal to
+    ---@returns boolean The condition
+    ---@returns string|nil The message
     function self.is_le(a, b, message)
       return self.is(a <= b,
         message or f "Expected `{a}` to be less than or equal to `{b}`\n")
     end
 
     --- Checks if a value is greater than another value.
-    --- @param a any - The first value to check
-    --- @param b any - The second value to check
-    --- @param message string|nil - The message to return if the values are not greater than
-    --- @return boolean - The condition
-    --- @return string|nil - The message
+    ---@param a any The first value to check
+    ---@param b any The second value to check
+    ---@param message string|nil The message to return if the values are not greater than
+    ---@returns boolean The condition
+    ---@returns string|nil The message
     function self.is_gt(a, b, message)
       return self.is(a > b,
         message or f "Expected `{a}` to be greater than `{b}`\n")
     end
 
     --- Checks if a value is greater than or equal to another value.
-    --- @param a any - The first value to check
-    --- @param b any - The second value to check
-    --- @param message string|nil - The message to return if the values are not greater than or equal to
-    --- @return boolean - The condition
-    --- @return string|nil - The message
+    ---@param a any The first value to check
+    ---@param b any The second value to check
+    ---@param message string|nil The message to return if the values are not greater than or equal to
+    ---@returns boolean The condition
+    ---@returns string|nil The message
     function self.is_ge(a, b, message)
       return self.is(a >= b, message or f "Expected `{a}` to be greater than or equal to `{b}`\n")
     end
 
     --- Checks if a value is of a specific type.
-    --- @param value any - The value to check
-    --- @param type string - The type to check against
-    --- @param message string|nil - The message to return if the values are not of the specified type
-    --- @return boolean - The condition
-    --- @return string|nil - The message
+    ---@param value any The value to check
+    ---@param type string The type to check against
+    ---@param message string|nil The message to return if the values are not of the specified type
+    ---@returns boolean The condition
+    ---@returns string|nil The message
     function self.is_type(value, expected_type, message)
       return self.is(type(value) == expected_type, message or f "Expected `{value}` to be of type `{expected_type}`\n")
     end
 
     --- Checks if two values are deeply equal.
-    --- @param a any - The first value to check
-    --- @param b any - The second value to check
-    --- @param message string|nil - The message to return if the values are not deeply equal
-    --- @return boolean - The condition
-    --- @return string|nil - The message
+    ---@param a any The first value to check
+    ---@param b any The second value to check
+    ---@param message string|nil The message to return if the values are not deeply equal
+    ---@returns boolean The condition
+    ---@returns string|nil The message
     function self.is_deeply(a, b, message)
       local result, mess
 

--- a/src/scripts/date.lua
+++ b/src/scripts/date.lua
@@ -11,9 +11,9 @@ local DateClass = Glu.glass.register({
     ---
     ---@param seconds number The number of seconds to convert.
     ---@param as_string boolean|nil Whether to return a single formatted string instead of three values. (Optional. Default is false.)
-    ---@returns string The zero-padded hours, or the single formatted string when `as_string` is true.
-    ---@returns string The zero-padded minutes. Not returned when `as_string` is true.
-    ---@returns string The zero-padded seconds. Not returned when `as_string` is true.
+    ---@return string hours The zero-padded hours, or the single formatted string when `as_string` is true.
+    ---@return string minutes The zero-padded minutes. Not returned when `as_string` is true.
+    ---@return string seconds The zero-padded seconds. Not returned when `as_string` is true.
     ---@example
     --- ```lua
     --- date.shms(3661)

--- a/src/scripts/date.lua
+++ b/src/scripts/date.lua
@@ -5,6 +5,22 @@ local DateClass = Glu.glass.register({
   setup = function(___, self, opts)
     local v = ___.v
 
+    --- Converts a number of seconds into hours, minutes, and seconds.
+    --- When `as_string` is true, returns a single human-readable string such as
+    --- "1h 2m 3s". Otherwise, returns three zero-padded "HH", "MM", "SS" strings.
+    ---
+    ---@param seconds number The number of seconds to convert.
+    ---@param as_string boolean|nil Whether to return a single formatted string instead of three values. (Optional. Default is false.)
+    ---@returns string The zero-padded hours, or the single formatted string when `as_string` is true.
+    ---@returns string The zero-padded minutes. Not returned when `as_string` is true.
+    ---@returns string The zero-padded seconds. Not returned when `as_string` is true.
+    ---@example
+    --- ```lua
+    --- date.shms(3661)
+    --- -- "01", "01", "01"
+    --- date.shms(3661, true)
+    --- -- "1h 1m 1s"
+    --- ```
     function self.shms(seconds, as_string)
       v.type(seconds, "number", 1, false)
       v.type(as_string, "boolean", 2, true)

--- a/src/scripts/dependency_queue.lua
+++ b/src/scripts/dependency_queue.lua
@@ -5,6 +5,13 @@ local DependencyQueueClass = Glu.glass.register({
   call = "new_dependency_queue",
   dependencies = { "queue", "table", },
   setup = function(___, self)
+    --- Builds a queue that installs any of the given Mudlet packages that are not already installed.
+    --- Filters out already-installed packages, wires up sysInstall and sysDownloadError event
+    --- handlers, and invokes the callback with success and a message when finished.
+    ---
+    ---@param packages table List of package descriptors, each a {name, url} table.
+    ---@param cb function Callback called with a success boolean and a message string when finished.
+    ---@returns object The dependency queue object.
     function self.new_dependency_queue(packages, cb)
       local installed = getPackages()
       local not_installed = table.n_filter(packages, function(package)
@@ -58,6 +65,8 @@ local DependencyQueueClass = Glu.glass.register({
         end
       )
 
+      --- Removes the registered event handlers and tears down the queue.
+      --- Deletes the named sysInstall and sysDownloadError handlers and clears the handler name and queue.
       function self.clean_up()
         deleteNamedEventHandler("glu", self.handler_name)
         deleteNamedEventHandler("glu", self.handler_name .. "_download_error")
@@ -65,6 +74,11 @@ local DependencyQueueClass = Glu.glass.register({
         self.queue = nil
       end
 
+      --- Begins executing the queue.
+      --- Executes the queue if it exists, otherwise returns a not-found error.
+      ---
+      ---@returns any|nil The result of the queue execution, or nil when the queue is not found.
+      ---@returns string? The error message "Queue not found" when the queue is missing.
       function self.start()
         if not self.queue then
           return nil, "Queue not found"

--- a/src/scripts/dependency_queue.lua
+++ b/src/scripts/dependency_queue.lua
@@ -11,7 +11,7 @@ local DependencyQueueClass = Glu.glass.register({
     ---
     ---@param packages table List of package descriptors, each a {name, url} table.
     ---@param cb function Callback called with a success boolean and a message string when finished.
-    ---@returns object The dependency queue object.
+    ---@return object self The dependency queue object.
     function self.new_dependency_queue(packages, cb)
       local installed = getPackages()
       local not_installed = table.n_filter(packages, function(package)
@@ -77,8 +77,8 @@ local DependencyQueueClass = Glu.glass.register({
       --- Begins executing the queue.
       --- Executes the queue if it exists, otherwise returns a not-found error.
       ---
-      ---@returns any|nil The result of the queue execution, or nil when the queue is not found.
-      ---@returns string? The error message "Queue not found" when the queue is missing.
+      ---@return any|nil result The result of the queue execution, or nil when the queue is not found.
+      ---@return string? err The error message "Queue not found" when the queue is missing.
       function self.start()
         if not self.queue then
           return nil, "Queue not found"

--- a/src/scripts/fd.lua
+++ b/src/scripts/fd.lua
@@ -15,8 +15,8 @@ local FdClass = Glu.glass.register({
     ---
     ---@param path string The path to split.
     ---@param dir_required boolean Whether the directory is required (Optional. Default is false).
-    ---@returns string|nil The directory portion, or nil if the path is invalid.
-    ---@returns string|nil The file portion, or nil if the path is invalid.
+    ---@return string|nil dir The directory portion, or nil if the path is invalid.
+    ---@return string|nil file The file portion, or nil if the path is invalid.
     function self.dir_file(path, dir_required)
       ___.v.type(path, "string", 1, false)
       ___.v.type(dir_required, "boolean", 2, true)
@@ -51,9 +51,9 @@ local FdClass = Glu.glass.register({
     --- ```
     ---
     ---@param path string The path to split.
-    ---@returns string|nil The root portion, or nil if the path is invalid.
-    ---@returns string|nil The directory portion, or nil if the path is invalid.
-    ---@returns string|nil The file portion, or nil if the path is invalid.
+    ---@return string|nil root The root portion, or nil if the path is invalid.
+    ---@return string|nil dir The directory portion, or nil if the path is invalid.
+    ---@return string|nil file The file portion, or nil if the path is invalid.
     function self.root_dir_file(path)
       ___.v.type(path, "string", 1, false)
 
@@ -69,7 +69,7 @@ local FdClass = Glu.glass.register({
 
     --- Checks if a file exists.
     ---@param path string The path to check.
-    ---@returns boolean Whether the file exists.
+    ---@return boolean exists Whether the file exists.
     ---@example
     --- ```lua
     --- fd.file_exists("path/to/file.txt")
@@ -86,7 +86,7 @@ local FdClass = Glu.glass.register({
 
     --- Checks if a directory exists.
     ---@param path string The path to check.
-    ---@returns boolean Whether the directory exists.
+    ---@return boolean exists Whether the directory exists.
     ---@example
     --- ```lua
     --- fd.dir_exists("path/to/directory")
@@ -104,9 +104,9 @@ local FdClass = Glu.glass.register({
     --- Reads a file.
     ---@param path string The path to the file.
     ---@param binary boolean Whether the file is binary (default false).
-    ---@returns string|nil The file contents, or nil on failure.
-    ---@returns string|nil The error message, if the read failed.
-    ---@returns number|nil The error code, if the read failed.
+    ---@return string|nil data The file contents, or nil on failure.
+    ---@return string|nil error The error message, if the read failed.
+    ---@return number|nil code The error code, if the read failed.
     ---@example
     --- ```lua
     --- fd.read_file("path/to/file.txt")
@@ -130,7 +130,7 @@ local FdClass = Glu.glass.register({
     ---@param data string The data to write to the file.
     ---@param overwrite boolean Whether to overwrite the file (default false).
     ---@param binary boolean Whether the file is binary (default false).
-    ---@returns string|table The path to the file or nil, a table with the error and code, or the attributes of the file.
+    ---@return string|table path The path to the file or nil, a table with the error and code, or the attributes of the file.
     ---@example
     --- ```lua
     --- fd.write_file("path/to/file.txt", "contents of file")
@@ -158,8 +158,8 @@ local FdClass = Glu.glass.register({
 
     --- Fixes a path to use forward slashes.
     ---@param path string The path to fix.
-    ---@returns string The fixed path.
-    ---@returns number The number of replacements made.
+    ---@return string path The fixed path.
+    ---@return number num The number of replacements made.
     ---@example
     --- ```lua
     --- fd.fix_path("path\\to\\file.txt")
@@ -180,7 +180,7 @@ local FdClass = Glu.glass.register({
     --- Checks for a forward slash first, then a backslash, returning the first found.
     ---
     ---@param path string The path to inspect.
-    ---@returns string|nil The path separator ("/" or "\\"), or nil if none is found.
+    ---@return string|nil sep The path separator ("/" or "\\"), or nil if none is found.
     function self.determine_path_separator(path)
       ___.v.type(path, "string", 1, false)
 
@@ -195,7 +195,7 @@ local FdClass = Glu.glass.register({
     --- This does not verify that the path exists on disk.
     ---
     ---@param path string The path string to check.
-    ---@returns boolean Whether the string contains a recognised path separator.
+    ---@return boolean is_valid Whether the string contains a recognised path separator.
     function self.valid_path_string(path)
       ___.v.type(path, "string", 1, false)
 
@@ -207,7 +207,7 @@ local FdClass = Glu.glass.register({
     --- single path string or a table of path strings.
     ---
     ---@param path string|table The path string, or table of path strings, to check.
-    ---@returns boolean Whether the argument is a valid path or table of paths.
+    ---@return boolean is_valid Whether the argument is a valid path or table of paths.
     function self.valid_path_table_or_string(path)
       path = ___.table.n_cast(path)
 
@@ -225,7 +225,7 @@ local FdClass = Glu.glass.register({
     --- Checks whether a path refers to an existing directory or file.
     ---
     ---@param path string The path to check.
-    ---@returns boolean Whether the path exists as a directory or a file.
+    ---@return boolean exists Whether the path exists as a directory or a file.
     function self.valid_path(path)
       ___.v.type(path, "string", 1, false)
 
@@ -236,7 +236,7 @@ local FdClass = Glu.glass.register({
     --- Each element must be a path that exists as either a directory or a file.
     ---
     ---@param paths table The uniform table of path strings to check.
-    ---@returns boolean Whether all paths in the table are valid existing paths.
+    ---@return boolean is_valid Whether all paths in the table are valid existing paths.
     function self.valid_paths(paths)
       ___.v.n_uniform(paths, "string", 1, false)
 
@@ -247,7 +247,7 @@ local FdClass = Glu.glass.register({
     --- Each element must be a path that exists as either a directory or a file.
     ---
     ---@param paths table The indexed table of path strings to check.
-    ---@returns boolean Whether all paths in the table are valid existing paths.
+    ---@return boolean is_valid Whether all paths in the table are valid existing paths.
     function self.valid_path_table(paths)
       ___.v.indexed(paths, "table", 1, false)
 
@@ -256,9 +256,9 @@ local FdClass = Glu.glass.register({
 
     --- Ensures that a directory exists.
     ---@param path string The path to the directory.
-    ---@returns table|nil A table of created directories, or nil on failure.
-    ---@returns string|nil The error message, if the operation failed.
-    ---@returns number|nil The error code, if the operation failed.
+    ---@return table|nil created A table of created directories, or nil on failure.
+    ---@return string|nil err The error message, if the operation failed.
+    ---@return number|nil code The error code, if the operation failed.
     ---@example
     --- ```lua
     --- fd.assure_dir("path/to/directory")
@@ -295,7 +295,7 @@ local FdClass = Glu.glass.register({
 
     --- Determines the root of a path.
     ---@param path string The path to determine the root of.
-    ---@returns string|nil The root of the path, or nil if the path is invalid.
+    ---@return string|nil root The root of the path, or nil if the path is invalid.
     ---@example
     --- ```lua
     --- fd.determine_root("c:\\test\\moo")
@@ -316,8 +316,8 @@ local FdClass = Glu.glass.register({
 
     --- Removes a file.
     ---@param path string The path to the file.
-    ---@returns boolean|nil Whether the file was removed, or nil on failure.
-    ---@returns string|nil The error message, if the removal failed.
+    ---@return boolean|nil removed Whether the file was removed, or nil on failure.
+    ---@return string|nil err The error message, if the removal failed.
     ---@example
     --- ```lua
     --- fd.rmfile("path/to/file.txt")
@@ -331,8 +331,8 @@ local FdClass = Glu.glass.register({
 
     --- Removes a directory.
     ---@param path string The path to the directory.
-    ---@returns boolean|nil Whether the directory was removed, or nil on failure.
-    ---@returns string|nil The error message, if the removal failed.
+    ---@return boolean|nil removed Whether the directory was removed, or nil on failure.
+    ---@return string|nil err The error message, if the removal failed.
     ---@example
     --- ```lua
     --- fd.rmdir("path/to/directory")
@@ -346,7 +346,7 @@ local FdClass = Glu.glass.register({
 
     --- Checks if a directory is empty.
     ---@param path string The path to the directory.
-    ---@returns boolean Whether the directory is empty.
+    ---@return boolean is_empty Whether the directory is empty.
     ---@example
     --- ```lua
     --- fd.dir_empty("/path/to/directory")
@@ -359,7 +359,7 @@ local FdClass = Glu.glass.register({
     --- Gets the files in a directory.
     ---@param path string The path to the directory.
     ---@param include_dots boolean Whether to include the "." and ".." directories (default false).
-    ---@returns table A table of files in the directory.
+    ---@return table result A table of files in the directory.
     ---@example
     --- ```lua
     --- fd.get_dir("/path/to/directory")
@@ -394,9 +394,9 @@ local FdClass = Glu.glass.register({
     --- Creates a unique temporary directory under the Mudlet home directory.
     --- The directory is placed at `<MudletHomeDir>/tmp/<id>` and created on disk.
     ---
-    ---@returns string|nil The path to the created temporary directory, or nil on failure.
-    ---@returns string|nil The error message, if creation failed.
-    ---@returns number|nil The error code, if creation failed.
+    ---@return string|nil dir The path to the created temporary directory, or nil on failure.
+    ---@return string|nil err The error message, if creation failed.
+    ---@return number|nil code The error code, if creation failed.
     function self.temp_dir()
       local dir = getMudletHomeDir() .. "/tmp/" .. ___.id()
 

--- a/src/scripts/fd.lua
+++ b/src/scripts/fd.lua
@@ -7,15 +7,16 @@ local FdClass = Glu.glass.register({
     ---
     --- If the directory is required and does not exist, nil is returned.
     ---
-    --- @example
+    ---@example
     --- ```lua
     --- fd.dir_file("path/to/file.txt")
     --- -- "path/to", "file.txt"
     --- ```
     ---
-    --- @param path string - The path to split.
-    --- @param dir_required boolean - Whether the directory is required (Optional. Default is false).
-    --- @return string|nil,string|nil - A table with the directory and file, or nil if the path is invalid.
+    ---@param path string The path to split.
+    ---@param dir_required boolean Whether the directory is required (Optional. Default is false).
+    ---@returns string|nil The directory portion, or nil if the path is invalid.
+    ---@returns string|nil The file portion, or nil if the path is invalid.
     function self.dir_file(path, dir_required)
       ___.v.type(path, "string", 1, false)
       ___.v.type(dir_required, "boolean", 2, true)
@@ -38,6 +39,21 @@ local FdClass = Glu.glass.register({
       return dir, file
     end
 
+    --- Splits a path into its root, directory, and file components.
+    --- The root is determined first, then the remainder is split into directory
+    --- and file. If the root or directory cannot be determined, all return values
+    --- are nil.
+    ---
+    ---@example
+    --- ```lua
+    --- fd.root_dir_file("c:/path/to/file.txt")
+    --- -- "c:", "/path/to", "file.txt"
+    --- ```
+    ---
+    ---@param path string The path to split.
+    ---@returns string|nil The root portion, or nil if the path is invalid.
+    ---@returns string|nil The directory portion, or nil if the path is invalid.
+    ---@returns string|nil The file portion, or nil if the path is invalid.
     function self.root_dir_file(path)
       ___.v.type(path, "string", 1, false)
 
@@ -52,9 +68,9 @@ local FdClass = Glu.glass.register({
     end
 
     --- Checks if a file exists.
-    --- @param path string - The path to check.
-    --- @return boolean - Whether the file exists.
-    --- @example
+    ---@param path string The path to check.
+    ---@returns boolean Whether the file exists.
+    ---@example
     --- ```lua
     --- fd.file_exists("path/to/file.txt")
     --- -- true
@@ -69,9 +85,9 @@ local FdClass = Glu.glass.register({
     end
 
     --- Checks if a directory exists.
-    --- @param path string - The path to check.
-    --- @return boolean - Whether the directory exists.
-    --- @example
+    ---@param path string The path to check.
+    ---@returns boolean Whether the directory exists.
+    ---@example
     --- ```lua
     --- fd.dir_exists("path/to/directory")
     --- -- true
@@ -86,10 +102,12 @@ local FdClass = Glu.glass.register({
     end
 
     --- Reads a file.
-    --- @param path string - The path to the file.
-    --- @param binary boolean - Whether the file is binary (default false).
-    --- @return ... any - The contents of the file.
-    --- @example
+    ---@param path string The path to the file.
+    ---@param binary boolean Whether the file is binary (default false).
+    ---@returns string|nil The file contents, or nil on failure.
+    ---@returns string|nil The error message, if the read failed.
+    ---@returns number|nil The error code, if the read failed.
+    ---@example
     --- ```lua
     --- fd.read_file("path/to/file.txt")
     --- -- "contents of file"
@@ -108,12 +126,12 @@ local FdClass = Glu.glass.register({
     end
 
     --- Writes to a file.
-    --- @param path string - The path to the file.
-    --- @param data string - The data to write to the file.
-    --- @param overwrite boolean - Whether to overwrite the file (default false).
-    --- @param binary boolean - Whether the file is binary (default false).
-    --- @return string|table - The path to the file or nil, a table with the error and code, or the attributes of the file.
-    --- @example
+    ---@param path string The path to the file.
+    ---@param data string The data to write to the file.
+    ---@param overwrite boolean Whether to overwrite the file (default false).
+    ---@param binary boolean Whether the file is binary (default false).
+    ---@returns string|table The path to the file or nil, a table with the error and code, or the attributes of the file.
+    ---@example
     --- ```lua
     --- fd.write_file("path/to/file.txt", "contents of file")
     --- -- "path/to/file.txt", "contents of file", nil
@@ -139,9 +157,10 @@ local FdClass = Glu.glass.register({
     end
 
     --- Fixes a path to use forward slashes.
-    --- @param path string - The path to fix.
-    --- @return string, number - The fixed path and the number of replacements made.
-    --- @example
+    ---@param path string The path to fix.
+    ---@returns string The fixed path.
+    ---@returns number The number of replacements made.
+    ---@example
     --- ```lua
     --- fd.fix_path("path\\to\\file.txt")
     --- -- "path/to/file.txt"
@@ -157,6 +176,11 @@ local FdClass = Glu.glass.register({
       return result, num
     end
 
+    --- Determines which path separator a path uses.
+    --- Checks for a forward slash first, then a backslash, returning the first found.
+    ---
+    ---@param path string The path to inspect.
+    ---@returns string|nil The path separator ("/" or "\\"), or nil if none is found.
     function self.determine_path_separator(path)
       ___.v.type(path, "string", 1, false)
 
@@ -167,18 +191,23 @@ local FdClass = Glu.glass.register({
       return nil
     end
 
+    --- Checks whether a string looks like a path by containing a path separator.
+    --- This does not verify that the path exists on disk.
+    ---
+    ---@param path string The path string to check.
+    ---@returns boolean Whether the string contains a recognised path separator.
     function self.valid_path_string(path)
       ___.v.type(path, "string", 1, false)
 
       return self.determine_path_separator(path) ~= nil
     end
 
-    function self.valid_path_table(paths)
-      ___.v.indexed(paths, "table", 1, false)
-
-      return ___.table.all(paths, self.valid_path_string)
-    end
-
+    --- Checks whether the argument is a valid path string or a table of valid path strings.
+    --- The argument is first normalised to a table, then validated as either a
+    --- single path string or a table of path strings.
+    ---
+    ---@param path string|table The path string, or table of path strings, to check.
+    ---@returns boolean Whether the argument is a valid path or table of paths.
     function self.valid_path_table_or_string(path)
       path = ___.table.n_cast(path)
 
@@ -193,18 +222,32 @@ local FdClass = Glu.glass.register({
       return false
     end
 
+    --- Checks whether a path refers to an existing directory or file.
+    ---
+    ---@param path string The path to check.
+    ---@returns boolean Whether the path exists as a directory or a file.
     function self.valid_path(path)
       ___.v.type(path, "string", 1, false)
 
       return self.dir_exists(path) or self.file_exists(path)
     end
 
+    --- Checks whether every entry in a table is a valid existing path.
+    --- Each element must be a path that exists as either a directory or a file.
+    ---
+    ---@param paths table The uniform table of path strings to check.
+    ---@returns boolean Whether all paths in the table are valid existing paths.
     function self.valid_paths(paths)
       ___.v.n_uniform(paths, "string", 1, false)
 
       return ___.table.all(paths, self.valid_path)
     end
 
+    --- Checks whether every entry in a table is a valid existing path.
+    --- Each element must be a path that exists as either a directory or a file.
+    ---
+    ---@param paths table The indexed table of path strings to check.
+    ---@returns boolean Whether all paths in the table are valid existing paths.
     function self.valid_path_table(paths)
       ___.v.indexed(paths, "table", 1, false)
 
@@ -212,9 +255,11 @@ local FdClass = Glu.glass.register({
     end
 
     --- Ensures that a directory exists.
-    --- @param path string - The path to the directory.
-    --- @return table|nil, string|nil, number|nil - A table of created directories, the error message, and the error code.
-    --- @example
+    ---@param path string The path to the directory.
+    ---@returns table|nil A table of created directories, or nil on failure.
+    ---@returns string|nil The error message, if the operation failed.
+    ---@returns number|nil The error code, if the operation failed.
+    ---@example
     --- ```lua
     --- fd.assure_dir("path/to/directory")
     --- ```
@@ -249,9 +294,9 @@ local FdClass = Glu.glass.register({
     end
 
     --- Determines the root of a path.
-    --- @param path string - The path to determine the root of.
-    --- @return string|nil - The root of the path, or nil if the path is invalid.
-    --- @example
+    ---@param path string The path to determine the root of.
+    ---@returns string|nil The root of the path, or nil if the path is invalid.
+    ---@example
     --- ```lua
     --- fd.determine_root("c:\\test\\moo")
     --- -- "c:"
@@ -270,9 +315,10 @@ local FdClass = Glu.glass.register({
     end
 
     --- Removes a file.
-    --- @param path string - The path to the file.
-    --- @return boolean|nil, nil|string - Whether the file was removed, or nil and the error message.
-    --- @example
+    ---@param path string The path to the file.
+    ---@returns boolean|nil Whether the file was removed, or nil on failure.
+    ---@returns string|nil The error message, if the removal failed.
+    ---@example
     --- ```lua
     --- fd.rmfile("path/to/file.txt")
     --- -- true
@@ -284,9 +330,10 @@ local FdClass = Glu.glass.register({
     end
 
     --- Removes a directory.
-    --- @param path string - The path to the directory.
-    --- @return boolean|nil, nil|string - Whether the directory was removed, or nil and the error message.
-    --- @example
+    ---@param path string The path to the directory.
+    ---@returns boolean|nil Whether the directory was removed, or nil on failure.
+    ---@returns string|nil The error message, if the removal failed.
+    ---@example
     --- ```lua
     --- fd.rmdir("path/to/directory")
     --- -- true
@@ -298,9 +345,9 @@ local FdClass = Glu.glass.register({
     end
 
     --- Checks if a directory is empty.
-    --- @param path string - The path to the directory.
-    --- @return boolean - Whether the directory is empty.
-    --- @example
+    ---@param path string The path to the directory.
+    ---@returns boolean Whether the directory is empty.
+    ---@example
     --- ```lua
     --- fd.dir_empty("/path/to/directory")
     --- -- true
@@ -310,10 +357,10 @@ local FdClass = Glu.glass.register({
     end
 
     --- Gets the files in a directory.
-    --- @param path string - The path to the directory.
-    --- @param include_dots boolean - Whether to include the "." and ".." directories (default false).
-    --- @return table - A table of files in the directory.
-    --- @example
+    ---@param path string The path to the directory.
+    ---@param include_dots boolean Whether to include the "." and ".." directories (default false).
+    ---@returns table A table of files in the directory.
+    ---@example
     --- ```lua
     --- fd.get_dir("/path/to/directory")
     --- -- {"file1", "file2", "file3"}
@@ -344,6 +391,12 @@ local FdClass = Glu.glass.register({
       return result
     end
 
+    --- Creates a unique temporary directory under the Mudlet home directory.
+    --- The directory is placed at `<MudletHomeDir>/tmp/<id>` and created on disk.
+    ---
+    ---@returns string|nil The path to the created temporary directory, or nil on failure.
+    ---@returns string|nil The error message, if creation failed.
+    ---@returns number|nil The error code, if creation failed.
     function self.temp_dir()
       local dir = getMudletHomeDir() .. "/tmp/" .. ___.id()
 

--- a/src/scripts/func.lua
+++ b/src/scripts/func.lua
@@ -3,6 +3,17 @@ local FuncClass = Glu.glass.register({
   class_name = "FuncClass",
   dependencies = {},
   setup = function(___, self)
+    --- Schedules a function to run after a delay.
+    --- Wraps Mudlet's `tempTimer`, forwarding any extra arguments to the function when it fires.
+    ---
+    ---@param func function The function to run after the delay.
+    ---@param delay number The delay in seconds before the function runs.
+    ---@param ... any Additional arguments passed to the function when it runs.
+    ---@returns number The timer id returned by tempTimer.
+    ---@example
+    --- ```lua
+    --- func.delay(function() echo("hi") end, 5)
+    --- ```
     function self.delay(func, delay, ...)
       ___.v.type(func, "function", 1, false)
       ___.v.type(delay, "number", 2, false)
@@ -14,6 +25,12 @@ local FuncClass = Glu.glass.register({
       end)
     end
 
+    --- Wraps a function with another function.
+    --- Returns a new function that calls the wrapper with the original function as its first argument, followed by any arguments passed to the new function.
+    ---
+    ---@param func function The function to be wrapped.
+    ---@param wrapper function The wrapper function, which receives `func` followed by the call arguments.
+    ---@returns function The wrapped function.
     function self.wrap(func, wrapper)
       --- ```lua
       --- local becho = function.wrap(cecho, function(func, text)
@@ -31,6 +48,18 @@ local FuncClass = Glu.glass.register({
       end
     end
 
+    --- Repeatedly runs a function on an interval.
+    --- Runs the function up to `times` times, waiting `interval` seconds between each run, forwarding any extra arguments to the function on each run.
+    ---
+    ---@param func function The function to run repeatedly.
+    ---@param interval number The interval in seconds between runs. Defaults to 1.
+    ---@param times number The number of times to run the function. Defaults to 1.
+    ---@param ... any Additional arguments passed to the function on each run.
+    ---@returns nil
+    ---@example
+    --- ```lua
+    --- func.repeater(function() echo("tick\n") end, 2, 3)
+    --- ```
     function self.repeater(func, interval, times, ...)
       ___.v.type(func, "function", 1, false)
       ___.v.type(interval, "number", 2, true)

--- a/src/scripts/func.lua
+++ b/src/scripts/func.lua
@@ -9,7 +9,7 @@ local FuncClass = Glu.glass.register({
     ---@param func function The function to run after the delay.
     ---@param delay number The delay in seconds before the function runs.
     ---@param ... any Additional arguments passed to the function when it runs.
-    ---@returns number The timer id returned by tempTimer.
+    ---@return number timer_id The timer id returned by tempTimer.
     ---@example
     --- ```lua
     --- func.delay(function() echo("hi") end, 5)
@@ -30,7 +30,7 @@ local FuncClass = Glu.glass.register({
     ---
     ---@param func function The function to be wrapped.
     ---@param wrapper function The wrapper function, which receives `func` followed by the call arguments.
-    ---@returns function The wrapped function.
+    ---@return function wrapped The wrapped function.
     function self.wrap(func, wrapper)
       --- ```lua
       --- local becho = function.wrap(cecho, function(func, text)
@@ -55,7 +55,7 @@ local FuncClass = Glu.glass.register({
     ---@param interval number The interval in seconds between runs. Defaults to 1.
     ---@param times number The number of times to run the function. Defaults to 1.
     ---@param ... any Additional arguments passed to the function on each run.
-    ---@returns nil
+    ---@return nil result
     ---@example
     --- ```lua
     --- func.repeater(function() echo("tick\n") end, 2, 3)

--- a/src/scripts/glass_loader.lua
+++ b/src/scripts/glass_loader.lua
@@ -5,6 +5,16 @@ local GlassLoaderClass = Glu.glass.register({
   dependencies = { "try", "http", "fd", "string" },
   setup = function(___, self, instance_opts, container)
 
+    --- Loads a "glass" (a Lua module/chunk) from a local file path or an
+    --- http(s) URL. URL loads are asynchronous and the result is delivered
+    --- through the callback. The loaded chunk can optionally be executed.
+    ---
+    ---@param opts table The options table. Fields: `path` (string) a local file path or http(s) URL, `cb`/`callback` (function, required) invoked with the loaded chunk on success or with (nil, errorMessage) on failure, and `execute` (boolean) whether to immediately execute the loaded chunk.
+    ---@returns boolean|nil Returns `false` and an error message when no callback is provided; otherwise returns nothing, as results are delivered through the callback.
+    ---@example
+    --- ```lua
+    --- glass_loader.load_glass({path = "https://example.com/thing.lua", cb = function(g, err) end})
+    --- ```
     function self.load_glass(opts)
       opts = opts or {}
       local path = opts.path

--- a/src/scripts/glass_loader.lua
+++ b/src/scripts/glass_loader.lua
@@ -10,7 +10,7 @@ local GlassLoaderClass = Glu.glass.register({
     --- through the callback. The loaded chunk can optionally be executed.
     ---
     ---@param opts table The options table. Fields: `path` (string) a local file path or http(s) URL, `cb`/`callback` (function, required) invoked with the loaded chunk on success or with (nil, errorMessage) on failure, and `execute` (boolean) whether to immediately execute the loaded chunk.
-    ---@returns boolean|nil Returns `false` and an error message when no callback is provided; otherwise returns nothing, as results are delivered through the callback.
+    ---@return boolean|nil ok Returns `false` and an error message when no callback is provided; otherwise returns nothing, as results are delivered through the callback.
     ---@example
     --- ```lua
     --- glass_loader.load_glass({path = "https://example.com/thing.lua", cb = function(g, err) end})

--- a/src/scripts/glu.lua
+++ b/src/scripts/glu.lua
@@ -305,7 +305,7 @@ if not _G["Glu"] then
     --- Delegates to Glu.glass.register and then instantiates the
     --- glass on this instance so it is immediately available.
     ---@param class_opts table Glass registration options (same as Glu.glass.register)
-    ---@returns table The registered glass class
+    ---@return table glass The registered glass class
     function instance.register(class_opts)
       local is_new = not Glu.has_glass(class_opts.name)
       local glass = Glu.glass.register(class_opts)
@@ -563,7 +563,7 @@ if not _G["Glu"] then
         --- Walks up the parent chain looking for a match against the base class.
         ---
         ---@param base_class table The base class to check against.
-        ---@returns boolean Whether this instance extends the base class.
+        ---@return boolean extends Whether this instance extends the base class.
         function self.extending(base_class)
           local current_instance = self
           while current_instance do

--- a/src/scripts/glu.lua
+++ b/src/scripts/glu.lua
@@ -304,8 +304,8 @@ if not _G["Glu"] then
     --- Register a glass on this instance after construction.
     --- Delegates to Glu.glass.register and then instantiates the
     --- glass on this instance so it is immediately available.
-    --- @param class_opts table Glass registration options (same as Glu.glass.register)
-    --- @return table The registered glass class
+    ---@param class_opts table Glass registration options (same as Glu.glass.register)
+    ---@returns table The registered glass class
     function instance.register(class_opts)
       local is_new = not Glu.has_glass(class_opts.name)
       local glass = Glu.glass.register(class_opts)
@@ -559,6 +559,11 @@ if not _G["Glu"] then
           G.setup(___, self, instance_opts, container)
         end
 
+        --- Determines whether this instance extends the given base class.
+        --- Walks up the parent chain looking for a match against the base class.
+        ---
+        ---@param base_class table The base class to check against.
+        ---@returns boolean Whether this instance extends the base class.
         function self.extending(base_class)
           local current_instance = self
           while current_instance do

--- a/src/scripts/http.lua
+++ b/src/scripts/http.lua
@@ -22,7 +22,7 @@ local HttpClass = Glu.glass.register({
     ---
     ---@param options table The options for the request.
     ---@param cb function The callback function.
-    ---@returns table The HTTP request object.
+    ---@return table request The HTTP request object.
     ---@example
     --- ```lua
     --- http.download({
@@ -45,7 +45,7 @@ local HttpClass = Glu.glass.register({
     ---
     ---@param options table The options for the request.
     ---@param cb function The callback function.
-    ---@returns table The HTTP request object.
+    ---@return table request The HTTP request object.
     ---@example
     --- ```lua
     --- http.get({
@@ -66,7 +66,7 @@ local HttpClass = Glu.glass.register({
     ---
     ---@param options table The options for the request.
     ---@param cb function The callback function.
-    ---@returns table The HTTP request object.
+    ---@return table request The HTTP request object.
     ---@example
     --- ```lua
     --- http.post({
@@ -87,7 +87,7 @@ local HttpClass = Glu.glass.register({
     ---
     ---@param options table The options for the request.
     ---@param cb function The callback function.
-    ---@returns table The HTTP request object.
+    ---@return table request The HTTP request object.
     ---@example
     --- ```lua
     --- http.put({
@@ -108,7 +108,7 @@ local HttpClass = Glu.glass.register({
     ---
     ---@param options table The options for the request.
     ---@param cb function The callback function.
-    ---@returns table The HTTP request object.
+    ---@return table request The HTTP request object.
     ---@example
     --- ```lua
     --- http.delete({
@@ -131,7 +131,7 @@ local HttpClass = Glu.glass.register({
     ---
     ---@param options table The options for the request.
     ---@param cb function The callback function.
-    ---@returns table The HTTP request object.
+    ---@return table request The HTTP request object.
     ---@example
     --- ```lua
     --- http.request({
@@ -159,7 +159,7 @@ local HttpClass = Glu.glass.register({
     --- Removes a tracked HTTP request from the request list by its id.
     ---
     ---@param id string The id of the request to remove.
-    ---@returns nil Nothing.
+    ---@return nil result Nothing.
     function self.delete_request(id)
       for i = 1, #requests do
         if requests[i].id == id then
@@ -172,7 +172,7 @@ local HttpClass = Glu.glass.register({
     --- Looks up a tracked HTTP request by its id.
     ---
     ---@param id string The id of the request to find.
-    ---@returns table|nil The matching request, or nil if none is found.
+    ---@return table|nil request The matching request, or nil if none is found.
     function self.find_request(id)
       for _, request in ipairs(requests) do
         if request.id == id then

--- a/src/scripts/http.lua
+++ b/src/scripts/http.lua
@@ -20,10 +20,10 @@ local HttpClass = Glu.glass.register({
     --- file, however, this is a bit more convenient as it does some checking
     --- for you.
     ---
-    --- @param options table - The options for the request.
-    --- @param cb function - The callback function.
-    --- @return table - The HTTP request object.
-    --- @example
+    ---@param options table The options for the request.
+    ---@param cb function The callback function.
+    ---@returns table The HTTP request object.
+    ---@example
     --- ```lua
     --- http.download({
     ---   url = "http://example.com/file.txt",
@@ -43,10 +43,10 @@ local HttpClass = Glu.glass.register({
     --- - `url` (`string`) - The URL to request.
     --- - `headers` (`table`) - The headers to send with the request.
     ---
-    --- @param options table - The options for the request.
-    --- @param cb function - The callback function.
-    --- @return table - The HTTP request object.
-    --- @example
+    ---@param options table The options for the request.
+    ---@param cb function The callback function.
+    ---@returns table The HTTP request object.
+    ---@example
     --- ```lua
     --- http.get({
     ---   url = "http://example.com/file.txt"
@@ -64,10 +64,10 @@ local HttpClass = Glu.glass.register({
     --- - `url` (`string`) - The URL to request.
     --- - `headers` (`table`) - The headers to send with the request.
     ---
-    --- @param options table - The options for the request.
-    --- @param cb function - The callback function.
-    --- @return table - The HTTP request object.
-    --- @example
+    ---@param options table The options for the request.
+    ---@param cb function The callback function.
+    ---@returns table The HTTP request object.
+    ---@example
     --- ```lua
     --- http.post({
     ---   url = "http://example.com/file.txt"
@@ -85,10 +85,10 @@ local HttpClass = Glu.glass.register({
     --- - `url` (`string`) - The URL to request.
     --- - `headers` (`table`) - The headers to send with the request.
     ---
-    --- @param options table - The options for the request.
-    --- @param cb function - The callback function.
-    --- @return table - The HTTP request object.
-    --- @example
+    ---@param options table The options for the request.
+    ---@param cb function The callback function.
+    ---@returns table The HTTP request object.
+    ---@example
     --- ```lua
     --- http.put({
     ---   url = "http://example.com/file.txt"
@@ -106,10 +106,10 @@ local HttpClass = Glu.glass.register({
     --- - `url` (`string`) - The URL to request.
     --- - `headers` (`table`) - The headers to send with the request.
     ---
-    --- @param options table - The options for the request.
-    --- @param cb function - The callback function.
-    --- @return table - The HTTP request object.
-    --- @example
+    ---@param options table The options for the request.
+    ---@param cb function The callback function.
+    ---@returns table The HTTP request object.
+    ---@example
     --- ```lua
     --- http.delete({
     ---   url = "http://example.com/file.txt"
@@ -129,10 +129,10 @@ local HttpClass = Glu.glass.register({
     --- - `method` (`string`) - The HTTP method to use.
     --- - `headers` (`table`) - The headers to send with the request.
     ---
-    --- @param options table - The options for the request.
-    --- @param cb function - The callback function.
-    --- @return table - The HTTP request object.
-    --- @example
+    ---@param options table The options for the request.
+    ---@param cb function The callback function.
+    ---@returns table The HTTP request object.
+    ---@example
     --- ```lua
     --- http.request({
     ---   url = "http://example.com/file.txt"
@@ -156,6 +156,10 @@ local HttpClass = Glu.glass.register({
       return request
     end
 
+    --- Removes a tracked HTTP request from the request list by its id.
+    ---
+    ---@param id string The id of the request to remove.
+    ---@returns nil Nothing.
     function self.delete_request(id)
       for i = 1, #requests do
         if requests[i].id == id then
@@ -165,6 +169,10 @@ local HttpClass = Glu.glass.register({
       end
     end
 
+    --- Looks up a tracked HTTP request by its id.
+    ---
+    ---@param id string The id of the request to find.
+    ---@returns table|nil The matching request, or nil if none is found.
     function self.find_request(id)
       for _, request in ipairs(requests) do
         if request.id == id then

--- a/src/scripts/http_request.lua
+++ b/src/scripts/http_request.lua
@@ -5,6 +5,18 @@ local HttpRequestClass = Glu.glass.register({
   setup = function(___, self, options)
     self.options = options
 
+    --- Performs the HTTP request described by `self.options`.
+    --- Registers Mudlet named event handlers for the matching sysHttp
+    --- Done/Error events, then invokes the appropriate global HTTP function
+    --- (`getHTTP`, `postHTTP`, `customHTTP`, etc.). On completion it builds an
+    --- `http_response`, writes the body to `saveTo` when requested, invokes the
+    --- callback, and cleans up its event handlers.
+    ---
+    ---@returns object The request object.
+    ---@example
+    --- ```lua
+    --- request.execute()
+    --- ```
     function self.execute()
       local owner = self.container
 

--- a/src/scripts/http_request.lua
+++ b/src/scripts/http_request.lua
@@ -12,7 +12,7 @@ local HttpRequestClass = Glu.glass.register({
     --- `http_response`, writes the body to `saveTo` when requested, invokes the
     --- callback, and cleans up its event handlers.
     ---
-    ---@returns object The request object.
+    ---@return object request The request object.
     ---@example
     --- ```lua
     --- request.execute()

--- a/src/scripts/number.lua
+++ b/src/scripts/number.lua
@@ -7,7 +7,7 @@ local NumberClass = Glu.glass.register({
     ---
     ---@param num number The number to round.
     ---@param digits number The number of digits to round to. (Optional. Default is 0.)
-    ---@returns number The rounded number.
+    ---@return number rounded The rounded number.
     ---@example
     --- ```lua
     --- number.round(3.14159, 2)
@@ -27,7 +27,7 @@ local NumberClass = Glu.glass.register({
     ---@param num number The number to clamp.
     ---@param min number The minimum allowed value.
     ---@param max number The maximum allowed value.
-    ---@returns number The clamped number.
+    ---@return number clamped The clamped number.
     ---@example
     --- ```lua
     --- number.clamp(10, 1, 100)
@@ -45,7 +45,7 @@ local NumberClass = Glu.glass.register({
     ---@param a number The starting value.
     ---@param b number The ending value.
     ---@param t number The interpolation factor (between 0 and 1).
-    ---@returns number The interpolated value.
+    ---@return number interpolated The interpolated value.
     ---@example
     --- ```lua
     --- number.lerp(0, 100, 0.5)
@@ -64,7 +64,7 @@ local NumberClass = Glu.glass.register({
     ---@param start number The starting value.
     ---@param end_val number The ending value.
     ---@param t number The interpolation factor (between 0 and 1).
-    ---@returns number The interpolated value.
+    ---@return number interpolated The interpolated value.
     ---@example
     --- ```lua
     --- number.lerp_smooth(0, 100, 0.5)
@@ -85,7 +85,7 @@ local NumberClass = Glu.glass.register({
     ---@param start number The starting value.
     ---@param end_val number The ending value.
     ---@param t number The interpolation factor (between 0 and 1).
-    ---@returns number The interpolated value.
+    ---@return number interpolated The interpolated value.
     ---@example
     --- ```lua
     function self.lerp_smoother(start, end_val, t)
@@ -103,7 +103,7 @@ local NumberClass = Glu.glass.register({
     ---@param start number The starting value.
     ---@param end_val number The target value.
     ---@param t number The interpolation factor (between 0 and 1).
-    ---@returns number The eased value.
+    ---@return number eased The eased value.
     ---@example
     --- ```lua
     function self.lerp_ease_in(start, end_val, t)
@@ -121,7 +121,7 @@ local NumberClass = Glu.glass.register({
     ---@param start number The starting value.
     ---@param end_val number The target value.
     ---@param t number The interpolation factor (between 0 and 1).
-    ---@returns number The eased value.
+    ---@return number eased The eased value.
     ---@example
     --- ```lua
     function self.lerp_ease_out(start, end_val, t)
@@ -141,7 +141,7 @@ local NumberClass = Glu.glass.register({
     ---@param in_max number The maximum of the input range.
     ---@param out_min number The minimum of the output range.
     ---@param out_max number The maximum of the output range.
-    ---@returns number The mapped number.
+    ---@return number mapped The mapped number.
     ---@example
     --- ```lua
     --- number.map(50, 0, 100, 0, 100)
@@ -159,7 +159,7 @@ local NumberClass = Glu.glass.register({
 
     --- Tests a number to see if it is positive, negative, or zero.
     ---@param num number The number to check.
-    ---@returns boolean True if the number is positive, false otherwise.
+    ---@return boolean is_positive True if the number is positive, false otherwise.
     ---@example
     --- ```lua
     --- number.positive(10)
@@ -175,7 +175,7 @@ local NumberClass = Glu.glass.register({
     ---@param a number The first number.
     ---@param b number The second number.
     ---@param percent_tolerance number The percentage allowed difference (default is 5%).
-    ---@returns boolean True if the numbers are approximately equal, false otherwise.
+    ---@return boolean ok True if the numbers are approximately equal, false otherwise.
     ---@example
     --- ```lua
     --- number.is_approximate(10, 11, 10)
@@ -193,7 +193,7 @@ local NumberClass = Glu.glass.register({
 
     --- Returns the minimum value in a list of numbers or a table.
     ---@param ... number|table[] Either a list of numbers or a single table of numbers.
-    ---@returns number The minimum value.
+    ---@return number result The minimum value.
     ---@example
     --- ```lua
     --- number.min(1, 2, 3)
@@ -214,7 +214,7 @@ local NumberClass = Glu.glass.register({
 
     --- Returns the maximum value in a list of numbers or a table of numbers.
     ---@param ... number|number[] Either a list of numbers or a single table of numbers.
-    ---@returns number The maximum value.
+    ---@return number result The maximum value.
     ---@example
     --- ```lua
     --- number.max(1, 2, 3)
@@ -235,7 +235,7 @@ local NumberClass = Glu.glass.register({
 
     --- Sums a list of numbers.
     ---@param ... number[] The numbers to sum.
-    ---@returns number The sum of the numbers.
+    ---@return number sum The sum of the numbers.
     ---@example
     --- ```lua
     --- number.sum(1, 2, 3)
@@ -250,7 +250,7 @@ local NumberClass = Glu.glass.register({
     --- Returns a random number between a minimum and maximum value.
     ---@param min number The minimum value.
     ---@param max number The maximum value.
-    ---@returns number The random number.
+    ---@return number random The random number.
     ---@example
     --- ```lua
     --- number.random_clamp(0, 100)
@@ -267,7 +267,7 @@ local NumberClass = Glu.glass.register({
     ---@param num number The number to check
     ---@param min number The minimum value
     ---@param max number The maximum value
-    ---@returns boolean True if the number is between min and max
+    ---@return boolean is_between True if the number is between min and max
     ---@example
     --- ```lua
     --- number.is_between(5, 1, 10)
@@ -282,7 +282,7 @@ local NumberClass = Glu.glass.register({
     end
 
     ---@param num number The number to check
-    ---@returns number The sign (-1, 0, or 1)
+    ---@return number sign The sign (-1, 0, or 1)
     ---@example
     --- ```lua
     --- number.sign(-5)
@@ -296,7 +296,7 @@ local NumberClass = Glu.glass.register({
 
     --- Calculates the average (mean) of a list of numbers
     ---@param ... number|number[] Either a list of numbers or a single table of numbers
-    ---@returns number The average value
+    ---@return number average The average value
     ---@example
     --- ```lua
     --- number.average(1, 2, 3)
@@ -311,7 +311,7 @@ local NumberClass = Glu.glass.register({
     --- Constrains a number to a certain precision
     ---@param num number The number to constrain
     ---@param precision number The precision (e.g., 0.1, 0.01, etc.)
-    ---@returns number The constrained number
+    ---@return number constrained The constrained number
     ---@example
     --- ```lua
     --- number.constrain(3.14159, 0.01)
@@ -328,7 +328,7 @@ local NumberClass = Glu.glass.register({
     ---@param value number The current value
     ---@param total number The total value
     ---@param round_digits? number Optional number of decimal places to round to
-    ---@returns number The percentage
+    ---@return number result The percentage
     ---@example
     --- ```lua
     --- number.percent_of(25, 20)
@@ -350,7 +350,7 @@ local NumberClass = Glu.glass.register({
     ---@param percent number The percentage
     ---@param total number The total value
     ---@param round_digits? number Optional number of decimal places to round to
-    ---@returns number The resulting value
+    ---@return number result The resulting value
     ---@example
     --- ```lua
     --- number.percent(25, 100)
@@ -374,7 +374,7 @@ local NumberClass = Glu.glass.register({
     ---@param num number The number to normalize
     ---@param min number The minimum value of the range
     ---@param max number The maximum value of the range
-    ---@returns number The normalized value (0-1)
+    ---@return number normalized The normalized value (0-1)
     ---@example
     --- ```lua
     --- number.normalize(50, 0, 100)
@@ -386,7 +386,7 @@ local NumberClass = Glu.glass.register({
 
     --- Calculates the arithmetic mean of a list of numbers
     ---@param ... number|number[] Either a list of numbers or a single table of numbers
-    ---@returns number The arithmetic mean
+    ---@return number mean The arithmetic mean
     ---@example
     --- ```lua
     --- number.mean(1, 2, 3)

--- a/src/scripts/number.lua
+++ b/src/scripts/number.lua
@@ -5,10 +5,10 @@ local NumberClass = Glu.glass.register({
   setup = function(___, self)
     --- Rounds a number to a specified number of decimal places.
     ---
-    --- @param num number - The number to round.
-    --- @param digits number - The number of digits to round to. (Optional. Default is 0.)
-    --- @return number - The rounded number.
-    --- @example
+    ---@param num number The number to round.
+    ---@param digits number The number of digits to round to. (Optional. Default is 0.)
+    ---@returns number The rounded number.
+    ---@example
     --- ```lua
     --- number.round(3.14159, 2)
     --- -- 3.14
@@ -24,11 +24,11 @@ local NumberClass = Glu.glass.register({
     end
 
     --- Clamps a number within a range.
-    --- @param num number - The number to clamp.
-    --- @param min number - The minimum allowed value.
-    --- @param max number - The maximum allowed value.
-    --- @return number - The clamped number.
-    --- @example
+    ---@param num number The number to clamp.
+    ---@param min number The minimum allowed value.
+    ---@param max number The maximum allowed value.
+    ---@returns number The clamped number.
+    ---@example
     --- ```lua
     --- number.clamp(10, 1, 100)
     --- -- 10
@@ -42,11 +42,11 @@ local NumberClass = Glu.glass.register({
     end
 
     --- Linearly interpolates between two numbers.
-    --- @param a number - The starting value.
-    --- @param b number - The ending value.
-    --- @param t number - The interpolation factor (between 0 and 1).
-    --- @return number - The interpolated value.
-    --- @example
+    ---@param a number The starting value.
+    ---@param b number The ending value.
+    ---@param t number The interpolation factor (between 0 and 1).
+    ---@returns number The interpolated value.
+    ---@example
     --- ```lua
     --- number.lerp(0, 100, 0.5)
     --- -- 50
@@ -61,11 +61,11 @@ local NumberClass = Glu.glass.register({
     end
 
     --- Smoothly interpolates between two numbers using a cubic function.
-    --- @param start number - The starting value.
-    --- @param end_val number - The ending value.
-    --- @param t number - The interpolation factor (between 0 and 1).
-    --- @return number - The interpolated value.
-    --- @example
+    ---@param start number The starting value.
+    ---@param end_val number The ending value.
+    ---@param t number The interpolation factor (between 0 and 1).
+    ---@returns number The interpolated value.
+    ---@example
     --- ```lua
     --- number.lerp_smooth(0, 100, 0.5)
     --- -- 50
@@ -82,11 +82,11 @@ local NumberClass = Glu.glass.register({
     end
 
     --- Smoothly interpolates between two numbers using a quintic function.
-    --- @param start number - The starting value.
-    --- @param end_val number - The ending value.
-    --- @param t number - The interpolation factor (between 0 and 1).
-    --- @return number - The interpolated value.
-    --- @example
+    ---@param start number The starting value.
+    ---@param end_val number The ending value.
+    ---@param t number The interpolation factor (between 0 and 1).
+    ---@returns number The interpolated value.
+    ---@example
     --- ```lua
     function self.lerp_smoother(start, end_val, t)
       ___.v.type(start, "number", 1, false)
@@ -100,11 +100,11 @@ local NumberClass = Glu.glass.register({
     end
 
     --- Eases a number in towards a target value.
-    --- @param start number - The starting value.
-    --- @param end_val number - The target value.
-    --- @param t number - The interpolation factor (between 0 and 1).
-    --- @return number - The eased value.
-    --- @example
+    ---@param start number The starting value.
+    ---@param end_val number The target value.
+    ---@param t number The interpolation factor (between 0 and 1).
+    ---@returns number The eased value.
+    ---@example
     --- ```lua
     function self.lerp_ease_in(start, end_val, t)
       ___.v.type(start, "number", 1, false)
@@ -118,11 +118,11 @@ local NumberClass = Glu.glass.register({
     end
 
     --- Eases a number out towards a target value.
-    --- @param start number - The starting value.
-    --- @param end_val number - The target value.
-    --- @param t number - The interpolation factor (between 0 and 1).
-    --- @return number - The eased value.
-    --- @example
+    ---@param start number The starting value.
+    ---@param end_val number The target value.
+    ---@param t number The interpolation factor (between 0 and 1).
+    ---@returns number The eased value.
+    ---@example
     --- ```lua
     function self.lerp_ease_out(start, end_val, t)
       ___.v.type(start, "number", 1, false)
@@ -136,13 +136,13 @@ local NumberClass = Glu.glass.register({
     end
 
     --- Maps a number from one range to another.
-    --- @param value number - The input number.
-    --- @param in_min number - The minimum of the input range.
-    --- @param in_max number - The maximum of the input range.
-    --- @param out_min number - The minimum of the output range.
-    --- @param out_max number - The maximum of the output range.
-    --- @return number - The mapped number.
-    --- @example
+    ---@param value number The input number.
+    ---@param in_min number The minimum of the input range.
+    ---@param in_max number The maximum of the input range.
+    ---@param out_min number The minimum of the output range.
+    ---@param out_max number The maximum of the output range.
+    ---@returns number The mapped number.
+    ---@example
     --- ```lua
     --- number.map(50, 0, 100, 0, 100)
     --- -- 50
@@ -158,9 +158,9 @@ local NumberClass = Glu.glass.register({
     end
 
     --- Tests a number to see if it is positive, negative, or zero.
-    --- @param num number - The number to check.
-    --- @return boolean - True if the number is positive, false otherwise.
-    --- @example
+    ---@param num number The number to check.
+    ---@returns boolean True if the number is positive, false otherwise.
+    ---@example
     --- ```lua
     --- number.positive(10)
     --- -- true
@@ -172,11 +172,11 @@ local NumberClass = Glu.glass.register({
     end
 
     --- Checks if two numbers are approximately equal within a percentage tolerance.
-    --- @param a number - The first number.
-    --- @param b number - The second number.
-    --- @param percent_tolerance number - The percentage allowed difference (default is 5%).
-    --- @return boolean - True if the numbers are approximately equal, false otherwise.
-    --- @example
+    ---@param a number The first number.
+    ---@param b number The second number.
+    ---@param percent_tolerance number The percentage allowed difference (default is 5%).
+    ---@returns boolean True if the numbers are approximately equal, false otherwise.
+    ---@example
     --- ```lua
     --- number.is_approximate(10, 11, 10)
     --- -- true
@@ -192,9 +192,9 @@ local NumberClass = Glu.glass.register({
     end
 
     --- Returns the minimum value in a list of numbers or a table.
-    --- @param ... number|table[] - Either a list of numbers or a single table of numbers.
-    --- @return number - The minimum value.
-    --- @example
+    ---@param ... number|table[] Either a list of numbers or a single table of numbers.
+    ---@returns number The minimum value.
+    ---@example
     --- ```lua
     --- number.min(1, 2, 3)
     --- -- 1
@@ -213,9 +213,9 @@ local NumberClass = Glu.glass.register({
     end
 
     --- Returns the maximum value in a list of numbers or a table of numbers.
-    --- @param ... number|number[] - Either a list of numbers or a single table of numbers.
-    --- @return number - The maximum value.
-    --- @example
+    ---@param ... number|number[] Either a list of numbers or a single table of numbers.
+    ---@returns number The maximum value.
+    ---@example
     --- ```lua
     --- number.max(1, 2, 3)
     --- -- 3
@@ -234,9 +234,9 @@ local NumberClass = Glu.glass.register({
     end
 
     --- Sums a list of numbers.
-    --- @param ... number[] - The numbers to sum.
-    --- @return number - The sum of the numbers.
-    --- @example
+    ---@param ... number[] The numbers to sum.
+    ---@returns number The sum of the numbers.
+    ---@example
     --- ```lua
     --- number.sum(1, 2, 3)
     --- -- 6
@@ -248,10 +248,10 @@ local NumberClass = Glu.glass.register({
     end
 
     --- Returns a random number between a minimum and maximum value.
-    --- @param min number - The minimum value.
-    --- @param max number - The maximum value.
-    --- @return number - The random number.
-    --- @example
+    ---@param min number The minimum value.
+    ---@param max number The maximum value.
+    ---@returns number The random number.
+    ---@example
     --- ```lua
     --- number.random_clamp(0, 100)
     --- -- 50
@@ -264,11 +264,11 @@ local NumberClass = Glu.glass.register({
     end
 
     --- Checks if a number is between two values (inclusive)
-    --- @param num number - The number to check
-    --- @param min number - The minimum value
-    --- @param max number - The maximum value
-    --- @return boolean - True if the number is between min and max
-    --- @example
+    ---@param num number The number to check
+    ---@param min number The minimum value
+    ---@param max number The maximum value
+    ---@returns boolean True if the number is between min and max
+    ---@example
     --- ```lua
     --- number.is_between(5, 1, 10)
     --- -- true
@@ -281,9 +281,9 @@ local NumberClass = Glu.glass.register({
       return num >= min and num <= max
     end
 
-    --- @param num number - The number to check
-    --- @return number - The sign (-1, 0, or 1)
-    --- @example
+    ---@param num number The number to check
+    ---@returns number The sign (-1, 0, or 1)
+    ---@example
     --- ```lua
     --- number.sign(-5)
     --- -- -1
@@ -295,9 +295,9 @@ local NumberClass = Glu.glass.register({
     end
 
     --- Calculates the average (mean) of a list of numbers
-    --- @param ... number|number[] - Either a list of numbers or a single table of numbers
-    --- @return number - The average value
-    --- @example
+    ---@param ... number|number[] Either a list of numbers or a single table of numbers
+    ---@returns number The average value
+    ---@example
     --- ```lua
     --- number.average(1, 2, 3)
     --- -- 2
@@ -309,10 +309,10 @@ local NumberClass = Glu.glass.register({
     end
 
     --- Constrains a number to a certain precision
-    --- @param num number - The number to constrain
-    --- @param precision number - The precision (e.g., 0.1, 0.01, etc.)
-    --- @return number - The constrained number
-    --- @example
+    ---@param num number The number to constrain
+    ---@param precision number The precision (e.g., 0.1, 0.01, etc.)
+    ---@returns number The constrained number
+    ---@example
     --- ```lua
     --- number.constrain(3.14159, 0.01)
     --- -- 3.14
@@ -325,11 +325,11 @@ local NumberClass = Glu.glass.register({
     end
 
     --- Calculates what percentage one number is of another
-    --- @param value number - The current value
-    --- @param total number - The total value
-    --- @param round_digits? number - Optional number of decimal places to round to
-    --- @return number - The percentage
-    --- @example
+    ---@param value number The current value
+    ---@param total number The total value
+    ---@param round_digits? number Optional number of decimal places to round to
+    ---@returns number The percentage
+    ---@example
     --- ```lua
     --- number.percent_of(25, 20)
     --- -- 5
@@ -347,11 +347,11 @@ local NumberClass = Glu.glass.register({
     end
 
     --- Calculates what number is a certain percentage of another
-    --- @param percent number - The percentage
-    --- @param total number - The total value
-    --- @param round_digits? number - Optional number of decimal places to round to
-    --- @return number - The resulting value
-    --- @example
+    ---@param percent number The percentage
+    ---@param total number The total value
+    ---@param round_digits? number Optional number of decimal places to round to
+    ---@returns number The resulting value
+    ---@example
     --- ```lua
     --- number.percent(25, 100)
     --- -- 25
@@ -371,11 +371,11 @@ local NumberClass = Glu.glass.register({
     end
 
     --- Normalizes a number to a 0-1 range
-    --- @param num number - The number to normalize
-    --- @param min number - The minimum value of the range
-    --- @param max number - The maximum value of the range
-    --- @return number - The normalized value (0-1)
-    --- @example
+    ---@param num number The number to normalize
+    ---@param min number The minimum value of the range
+    ---@param max number The maximum value of the range
+    ---@returns number The normalized value (0-1)
+    ---@example
     --- ```lua
     --- number.normalize(50, 0, 100)
     --- -- 0.5
@@ -385,9 +385,9 @@ local NumberClass = Glu.glass.register({
     end
 
     --- Calculates the arithmetic mean of a list of numbers
-    --- @param ... number|number[] - Either a list of numbers or a single table of numbers
-    --- @return number - The arithmetic mean
-    --- @example
+    ---@param ... number|number[] Either a list of numbers or a single table of numbers
+    ---@returns number The arithmetic mean
+    ---@example
     --- ```lua
     --- number.mean(1, 2, 3)
     --- -- 2

--- a/src/scripts/preferences.lua
+++ b/src/scripts/preferences.lua
@@ -6,11 +6,11 @@ local PreferencesClass = Glu.glass.register({
     --- Loads preferences from a file. If a package name is provided, it will be
     --- used to construct the path. Otherwise, the file will be loaded from the
     --- profile directory.
-    --- @param pkg string|nil - The package name. (Optional. Default is nil.)
-    --- @param file string - The file name.
-    --- @param defaults table - A table of default values for those which are missing.
-    --- @return table - The loaded preferences.
-    --- @example
+    ---@param pkg string|nil The package name. (Optional. Default is nil.)
+    ---@param file string The file name.
+    ---@param defaults table A table of default values for those which are missing.
+    ---@returns table The loaded preferences.
+    ---@example
     --- ```lua
     --- -- Load preferences from the "my_package" package
     --- preferences.load_prefs("my_package", "settings.json", {
@@ -42,10 +42,10 @@ local PreferencesClass = Glu.glass.register({
     --- Saves preferences to a file. If a package name is provided, it will be
     --- used to construct the path. Otherwise, the file will be saved to the
     --- profile directory.
-    --- @param pkg string|nil - The package name. (Optional. Default is nil.)
-    --- @param file string - The file name.
-    --- @param prefs table - The preferences to save.
-    --- @example
+    ---@param pkg string|nil The package name. (Optional. Default is nil.)
+    ---@param file string The file name.
+    ---@param prefs table The preferences to save.
+    ---@example
     --- ```lua
     --- preferences.save_prefs("my_package", "settings.json", {
     ---   default_value = 1,

--- a/src/scripts/preferences.lua
+++ b/src/scripts/preferences.lua
@@ -9,7 +9,7 @@ local PreferencesClass = Glu.glass.register({
     ---@param pkg string|nil The package name. (Optional. Default is nil.)
     ---@param file string The file name.
     ---@param defaults table A table of default values for those which are missing.
-    ---@returns table The loaded preferences.
+    ---@return table prefs The loaded preferences.
     ---@example
     --- ```lua
     --- -- Load preferences from the "my_package" package

--- a/src/scripts/queue.lua
+++ b/src/scripts/queue.lua
@@ -13,10 +13,10 @@ local QueueClass = Glu.glass.register({
     --- is available both through the queue object and the functions from this
     --- module. The ID is in the form of a v4 UUID.
     ---
-    --- @param funcs table? - A table of functions to be added to the queue
-    --- @return table - The new queue object
+    ---@param funcs table? A table of functions to be added to the queue
+    ---@returns table The new queue object
     ---
-    --- @example
+    ---@example
     --- ```lua
     --- local queue = queue.new(parent).new({})
     --- ```
@@ -34,8 +34,8 @@ local QueueClass = Glu.glass.register({
     --- Retrieves a queue object by its identifier. If no queue is found, nil is
     --- returned, otherwise the queue object is returned.
     ---
-    --- @param id string - The identifier of the queue to retrieve
-    --- @return table|nil - The queue object or nil if not found
+    ---@param id string The identifier of the queue to retrieve
+    ---@returns table|nil The queue object or nil if not found
     function self.get(id)
       ___.v.type(id, "string", 1, false)
 
@@ -47,9 +47,9 @@ local QueueClass = Glu.glass.register({
 
     --- Add a function to the end of a queue by its identifier.
     ---
-    --- @param id string - The identifier of the queue to add the function to
-    --- @param f function - The function to add to the queue
-    --- @example
+    ---@param id string The identifier of the queue to add the function to
+    ---@param f function The function to add to the queue
+    ---@example
     --- ```lua
     --- queue:push("2ce02d6a-36a8-45ab-a78e-7f909427e1d1",
     ---   function() print("Hello, world!")
@@ -65,6 +65,11 @@ local QueueClass = Glu.glass.register({
       return q.push(f)
     end
 
+    --- Removes and returns the next item from the named queue.
+    ---
+    ---@param id string The identifier of the queue to shift from.
+    ---@returns any The next item removed from the queue, or nil on failure.
+    ---@returns string An error message if the queue could not be found.
     function self.shift(id)
       ___.v.type(id, "string", 1, false)
 

--- a/src/scripts/queue.lua
+++ b/src/scripts/queue.lua
@@ -14,7 +14,7 @@ local QueueClass = Glu.glass.register({
     --- module. The ID is in the form of a v4 UUID.
     ---
     ---@param funcs table? A table of functions to be added to the queue
-    ---@returns table The new queue object
+    ---@return table queue The new queue object
     ---
     ---@example
     --- ```lua
@@ -35,7 +35,7 @@ local QueueClass = Glu.glass.register({
     --- returned, otherwise the queue object is returned.
     ---
     ---@param id string The identifier of the queue to retrieve
-    ---@returns table|nil The queue object or nil if not found
+    ---@return table|nil queue The queue object or nil if not found
     function self.get(id)
       ___.v.type(id, "string", 1, false)
 
@@ -68,8 +68,8 @@ local QueueClass = Glu.glass.register({
     --- Removes and returns the next item from the named queue.
     ---
     ---@param id string The identifier of the queue to shift from.
-    ---@returns any The next item removed from the queue, or nil on failure.
-    ---@returns string An error message if the queue could not be found.
+    ---@return any item The next item removed from the queue, or nil on failure.
+    ---@return string err An error message if the queue could not be found.
     function self.shift(id)
       ___.v.type(id, "string", 1, false)
 

--- a/src/scripts/queue_stack.lua
+++ b/src/scripts/queue_stack.lua
@@ -12,7 +12,7 @@ local QueueStackClass = Glu.glass.register({
     --- Pushes a function onto the end of the queue.
     ---
     ---@param f function The task function to add to the queue.
-    ---@returns number The new length of the queue.
+    ---@return number length The new length of the queue.
     function self.push(f)
       ___.v.type(f, "function", 1, false)
       return ___.table.push(self.stack, f)
@@ -20,7 +20,7 @@ local QueueStackClass = Glu.glass.register({
 
     --- Removes and returns the first task from the front of the queue.
     ---
-    ---@returns function|nil The shifted task function, or nil if the queue is empty.
+    ---@return function|nil task The shifted task function, or nil if the queue is empty.
     function self.shift()
       return ___.table.shift(self.stack)
     end
@@ -28,9 +28,9 @@ local QueueStackClass = Glu.glass.register({
     --- Shifts the next task off the queue and executes it with the provided arguments.
     ---
     ---@param ... any The arguments to pass to the task function.
-    ---@returns QueueStackClass The queue object.
-    ---@returns number|nil The number of remaining tasks, or nil when the queue is empty.
-    ---@returns any ... Any results returned by the executed task.
+    ---@return QueueStackClass self The queue object.
+    ---@return number|nil count The number of remaining tasks, or nil when the queue is empty.
+    ---@return any ... Any results returned by the executed task.
     function self.execute(...)
       -- Shift the next task off the queue
       local task = self.shift()

--- a/src/scripts/queue_stack.lua
+++ b/src/scripts/queue_stack.lua
@@ -9,15 +9,28 @@ local QueueStackClass = Glu.glass.register({
     self.stack = funcs
     self.id = ___.id()
 
+    --- Pushes a function onto the end of the queue.
+    ---
+    ---@param f function The task function to add to the queue.
+    ---@returns number The new length of the queue.
     function self.push(f)
       ___.v.type(f, "function", 1, false)
       return ___.table.push(self.stack, f)
     end
 
+    --- Removes and returns the first task from the front of the queue.
+    ---
+    ---@returns function|nil The shifted task function, or nil if the queue is empty.
     function self.shift()
       return ___.table.shift(self.stack)
     end
 
+    --- Shifts the next task off the queue and executes it with the provided arguments.
+    ---
+    ---@param ... any The arguments to pass to the task function.
+    ---@returns QueueStackClass The queue object.
+    ---@returns number|nil The number of remaining tasks, or nil when the queue is empty.
+    ---@returns any ... Any results returned by the executed task.
     function self.execute(...)
       -- Shift the next task off the queue
       local task = self.shift()

--- a/src/scripts/same.lua
+++ b/src/scripts/same.lua
@@ -6,7 +6,7 @@ local SameClass = Glu.glass.register({
     --- Checks if two values are the same, including special cases for NaN and zero.
     ---@param value1 any The first value to compare.
     ---@param value2 any The second value to compare.
-    ---@returns boolean True if the values are the same, false otherwise.
+    ---@return boolean same True if the values are the same, false otherwise.
     function self.value_zero(value1, value2)
       ___.v.type(value1, "any", 1, false)
       ___.v.type(value2, "any", 2, false)
@@ -37,7 +37,7 @@ local SameClass = Glu.glass.register({
     --- Checks if two values are the same, including special cases for NaN and zero.
     ---@param value1 any The first value to compare.
     ---@param value2 any The second value to compare.
-    ---@returns boolean True if the values are the same, false otherwise.
+    ---@return boolean same True if the values are the same, false otherwise.
     function self.value(value1, value2)
       ___.v.type(value1, "any", 1, false)
       ___.v.type(value2, "any", 2, false)

--- a/src/scripts/same.lua
+++ b/src/scripts/same.lua
@@ -4,9 +4,9 @@ local SameClass = Glu.glass.register({
   dependencies = { "table" },
   setup = function(___, self)
     --- Checks if two values are the same, including special cases for NaN and zero.
-    --- @param value1 any - The first value to compare.
-    --- @param value2 any - The second value to compare.
-    --- @return boolean - True if the values are the same, false otherwise.
+    ---@param value1 any The first value to compare.
+    ---@param value2 any The second value to compare.
+    ---@returns boolean True if the values are the same, false otherwise.
     function self.value_zero(value1, value2)
       ___.v.type(value1, "any", 1, false)
       ___.v.type(value2, "any", 2, false)
@@ -35,9 +35,9 @@ local SameClass = Glu.glass.register({
     end
 
     --- Checks if two values are the same, including special cases for NaN and zero.
-    --- @param value1 any - The first value to compare.
-    --- @param value2 any - The second value to compare.
-    --- @return boolean - True if the values are the same, false otherwise.
+    ---@param value1 any The first value to compare.
+    ---@param value2 any The second value to compare.
+    ---@returns boolean True if the values are the same, false otherwise.
     function self.value(value1, value2)
       ___.v.type(value1, "any", 1, false)
       ___.v.type(value2, "any", 2, false)

--- a/src/scripts/string.lua
+++ b/src/scripts/string.lua
@@ -5,9 +5,9 @@ local StringClass = Glu.glass.register({
   setup = function(___, self)
     --- Capitalizes the first character of a string.
     ---
-    --- @param str string - The string to capitalize.
-    --- @return string - The capitalized string.
-    --- @example
+    ---@param str string The string to capitalize.
+    ---@returns string The capitalized string.
+    ---@example
     --- ```lua
     --- string.capitalize("hello")
     --- -- "Hello"
@@ -22,9 +22,9 @@ local StringClass = Glu.glass.register({
 
     --- Trims whitespace from the beginning and end of a string.
     ---
-    --- @param str string - The string to trim.
-    --- @return string - The trimmed string.
-    --- @example
+    ---@param str string The string to trim.
+    ---@returns string The trimmed string.
+    ---@example
     --- ```lua
     --- string.trim("  hello  ")
     --- -- "hello"
@@ -36,9 +36,9 @@ local StringClass = Glu.glass.register({
 
     --- Trims whitespace from the left side of a string.
     ---
-    --- @param str string - The string to trim.
-    --- @return string - The trimmed string.
-    --- @example
+    ---@param str string The string to trim.
+    ---@returns string The trimmed string.
+    ---@example
     --- ```lua
     --- string.ltrim("  hello  ")
     --- -- "hello  "
@@ -50,9 +50,9 @@ local StringClass = Glu.glass.register({
 
     --- Trims whitespace from the right side of a string.
     ---
-    --- @param str string - The string to trim.
-    --- @return string - The trimmed string.
-    --- @example
+    ---@param str string The string to trim.
+    ---@returns string The trimmed string.
+    ---@example
     --- ```lua
     --- string.rtrim("  hello  ")
     --- -- "  hello"
@@ -64,9 +64,9 @@ local StringClass = Glu.glass.register({
 
     --- Strips line breaks from a string.
     ---
-    --- @param str string - The string to strip line breaks from.
-    --- @return string - The string with line breaks removed.
-    --- @example
+    ---@param str string The string to strip line breaks from.
+    ---@returns string The string with line breaks removed.
+    ---@example
     --- ```lua
     --- string.strip_linebreaks("hello\nworld")
     --- -- "helloworld"
@@ -79,11 +79,11 @@ local StringClass = Glu.glass.register({
 
     --- Replaces all occurrences of a pattern in a string.
     ---
-    --- @param str string - The string to replace occurrences in.
-    --- @param pattern string - The pattern to replace.
-    --- @param replacement string - The replacement string.
-    --- @return string - The string with occurrences replaced.
-    --- @example
+    ---@param str string The string to replace occurrences in.
+    ---@param pattern string The pattern to replace.
+    ---@param replacement string The replacement string.
+    ---@returns string The string with occurrences replaced.
+    ---@example
     --- ```lua
     --- string.replace("hello world", "o", "a")
     --- -- "hella warld"
@@ -104,10 +104,10 @@ local StringClass = Glu.glass.register({
     --- delimiter is provided, it defaults to ".", which will split the string
     --- into individual characters.
     ---
-    --- @param str string - The string to split.
-    --- @param delimiter string - The regex delimiter to split the string by.
-    --- @return table - The split string.
-    --- @example
+    ---@param str string The string to split.
+    ---@param delimiter string The regex delimiter to split the string by.
+    ---@returns table The split string.
+    ---@example
     --- ```lua
     --- string.split("hello world")
     --- -- {"h", "e", "l", "l", "o", " ", "w", "o", "r", "l", "d"}
@@ -138,10 +138,10 @@ local StringClass = Glu.glass.register({
     --- Walks over a string or table, splitting the string with a PCRE regex
     --- delimiter and returning an iterator.
     ---
-    --- @param input string - The string to walk over.
-    --- @param delimiter string - The regex delimiter to split the string by.
-    --- @return function - The iterator function.
-    --- @example
+    ---@param input string The string to walk over.
+    ---@param delimiter string The regex delimiter to split the string by.
+    ---@returns function The iterator function.
+    ---@example
     --- ```lua
     --- for i, part in string.walk("hello world") do
     ---   print(i, part) -- prints 1=h, 2=e, 3=l, 4=l, 5=o, 6= , 7=w, 8=o, 9=r, 10=l, 11=d
@@ -164,15 +164,15 @@ local StringClass = Glu.glass.register({
     --- Formats a number with thousands separators and decimal places.
     --- If not specified, defaults to "," for thousands and "." for decimal.
     ---
-    --- @example
+    ---@example
     --- ```lua
     --- string.format_number(1234567.89)
     --- -- "1,234,567.89"
     --- ```
-    --- @param number string|number - The number to format (number or string)
-    --- @param thousands string - The thousands separator (optional, defaults to ",")
-    --- @param decimal string - The decimal separator (optional, defaults to ".")
-    --- @return string - The formatted number
+    ---@param number string|number The number to format (number or string)
+    ---@param thousands string The thousands separator (optional, defaults to ",")
+    ---@param decimal string The decimal separator (optional, defaults to ".")
+    ---@returns string The formatted number
     function self.format_number(number, thousands, decimal)
       ___.v.type(number, "number|string", 1, false)
       ___.v.type(thousands, "string", 2, true)
@@ -216,11 +216,11 @@ local StringClass = Glu.glass.register({
 
     --- Parses a formatted number string back to a number.
     ---
-    --- @param str string - The formatted number string.
-    --- @param thousands string - The thousands separator (optional, defaults to ",").
-    --- @param decimal string - The decimal separator (optional, defaults to ".").
-    --- @return number - The parsed number.
-    --- @example
+    ---@param str string The formatted number string.
+    ---@param thousands string The thousands separator (optional, defaults to ",").
+    ---@param decimal string The decimal separator (optional, defaults to ".").
+    ---@returns number The parsed number.
+    ---@example
     --- ```lua
     --- string.parse_formatted_number("1,234,567.89")
     --- -- 1234567.89
@@ -248,10 +248,10 @@ local StringClass = Glu.glass.register({
     --- Checks if a string starts with a given PCRE regex pattern.
     --- If the pattern does not start with "^", it is prepended with "^".
     ---
-    --- @param str string - The string to check.
-    --- @param start string - The pattern to check for.
-    --- @return boolean - Whether the string starts with the pattern.
-    --- @example
+    ---@param str string The string to check.
+    ---@param start string The pattern to check for.
+    ---@returns boolean Whether the string starts with the pattern.
+    ---@example
     --- ```lua
     --- string.starts_with("hello world", "hello")
     --- -- true
@@ -268,10 +268,10 @@ local StringClass = Glu.glass.register({
     --- Checks if a string ends with a given PCRE regex pattern.
     --- If the pattern does not end with "$", it is appended with "$".
     ---
-    --- @param str string - The string to check.
-    --- @param ending string - The pattern to check for.
-    --- @return boolean - Whether the string ends with the pattern.
-    --- @example
+    ---@param str string The string to check.
+    ---@param ending string The pattern to check for.
+    ---@returns boolean Whether the string ends with the pattern.
+    ---@example
     --- ```lua
     --- string.ends_with("hello world", "world")
     --- -- true
@@ -289,10 +289,10 @@ local StringClass = Glu.glass.register({
     --- may not start with "^" or end with "$". For those, use
     --- `string.starts_with` and `string.ends_with`.
     ---
-    --- @param str string - The string to check.
-    --- @param pattern string - The pattern to check for.
-    --- @return boolean - Whether the string contains the pattern.
-    --- @example
+    ---@param str string The string to check.
+    ---@param pattern string The pattern to check for.
+    ---@returns boolean Whether the string contains the pattern.
+    ---@example
     --- ```lua
     --- string.contains("hello world", "world")
     --- -- true
@@ -308,10 +308,10 @@ local StringClass = Glu.glass.register({
 
     --- Appends a suffix to a string if it does not already end with the suffix.
     ---
-    --- @param str string - The string to append to.
-    --- @param suffix string - The suffix to append.
-    --- @return string - The string with the suffix appended.
-    --- @example
+    ---@param str string The string to append to.
+    ---@param suffix string The suffix to append.
+    ---@returns string The string with the suffix appended.
+    ---@example
     --- ```lua
     --- string.append("hello", " world")
     --- -- "hello world"
@@ -325,10 +325,10 @@ local StringClass = Glu.glass.register({
 
     --- Prepends a prefix to a string if it does not already start with the prefix.
     ---
-    --- @param str string - The string to prepend to.
-    --- @param prefix string - The prefix to prepend.
-    --- @return string - The string with the prefix prepended.
-    --- @example
+    ---@param str string The string to prepend to.
+    ---@param prefix string The prefix to prepend.
+    ---@returns string The string with the prefix prepended.
+    ---@example
     --- ```lua
     --- string.prepend("world", "hello ")
     --- -- "hello world"
@@ -341,12 +341,13 @@ local StringClass = Glu.glass.register({
     end
 
     --- Implementation of reg_assoc for Mudlet using rex PCRE support
-    --- @param text string - The text to search through
-    --- @param patterns table - The patterns to search for
-    --- @param tokens table - The tokens to replace the patterns with
-    --- @param default_token string - The default token to use if no pattern is found (optional, defaults to "")
-    --- @return table,table - A table of results and token list
-    --- @example
+    ---@param text string The text to search through
+    ---@param patterns table The patterns to search for
+    ---@param tokens table The tokens to replace the patterns with
+    ---@param default_token string The default token to use if no pattern is found (optional, defaults to "")
+    ---@returns table A table of match results.
+    ---@returns table The list of replacement tokens.
+    ---@example
     --- ```lua
     --- string.reg_assoc("hello world", {"hello", "world"}, {"foo", "bar"})
     --- -- {"foo", "bar"}
@@ -399,6 +400,15 @@ local StringClass = Glu.glass.register({
       return results, token_list
     end
 
+    --- Determines whether a single character is an alphabetic letter.
+    ---
+    ---@param char string The single character to test.
+    ---@returns boolean True if the character is a letter (a-z, A-Z).
+    ---@example
+    --- ```lua
+    --- string.is_alpha("a")
+    --- -- true
+    --- ```
     function self.is_alpha(char)
       ___.v.type(char, "string", 1, false)
       ___.v.test(#char == 1, "Expected a single character", 1)
@@ -406,6 +416,15 @@ local StringClass = Glu.glass.register({
       return rex.match(char, "^[a-zA-Z]$") ~= nil
     end
 
+    --- Determines whether a single character is a numeric digit.
+    ---
+    ---@param char string The single character to test.
+    ---@returns boolean True if the character is a digit (0-9).
+    ---@example
+    --- ```lua
+    --- string.is_numeric("5")
+    --- -- true
+    --- ```
     function self.is_numeric(char)
       ___.v.type(char, "string", 1, false)
       ___.v.test(#char == 1, "Expected a single character", 1)
@@ -413,6 +432,15 @@ local StringClass = Glu.glass.register({
       return rex.match(char, "^[0-9]$") ~= nil
     end
 
+    --- Determines whether a single character is alphanumeric.
+    ---
+    ---@param char string The single character to test.
+    ---@returns boolean True if the character is a letter or digit (a-z, A-Z, 0-9).
+    ---@example
+    --- ```lua
+    --- string.is_alphanumeric("a")
+    --- -- true
+    --- ```
     function self.is_alphanumeric(char)
       ___.v.type(char, "string", 1, false)
       ___.v.test(#char == 1, "Expected a single character", 1)
@@ -420,6 +448,15 @@ local StringClass = Glu.glass.register({
       return rex.match(char, "^[a-zA-Z0-9]$") ~= nil
     end
 
+    --- Determines whether a single character is a whitespace character.
+    ---
+    ---@param char string The single character to test.
+    ---@returns boolean True if the character is whitespace.
+    ---@example
+    --- ```lua
+    --- string.is_whitespace(" ")
+    --- -- true
+    --- ```
     function self.is_whitespace(char)
       ___.v.type(char, "string", 1, false)
       ___.v.test(#char == 1, "Expected a single character", 1)
@@ -427,6 +464,16 @@ local StringClass = Glu.glass.register({
       return rex.match(char, "^\\s$") ~= nil
     end
 
+    --- Determines whether a single character is a punctuation character, meaning
+    --- it is neither alphanumeric nor whitespace.
+    ---
+    ---@param char string The single character to test.
+    ---@returns boolean True if the character is punctuation.
+    ---@example
+    --- ```lua
+    --- string.is_punctuation("!")
+    --- -- true
+    --- ```
     function self.is_punctuation(char)
       ___.v.type(char, "string", 1, false)
       ___.v.test(#char == 1, "Expected a single character", 1)
@@ -434,6 +481,15 @@ local StringClass = Glu.glass.register({
       return rex.match(char, "^[^a-zA-Z0-9\\s]$") ~= nil
     end
 
+    --- Determines whether a single character is an uppercase letter.
+    ---
+    ---@param char string The single character to test.
+    ---@returns boolean True if the character is an uppercase letter (A-Z).
+    ---@example
+    --- ```lua
+    --- string.is_uppercase("A")
+    --- -- true
+    --- ```
     function self.is_uppercase(char)
       ___.v.type(char, "string", 1, false)
       ___.v.test(#char == 1, "Expected a single character", 1)
@@ -441,6 +497,15 @@ local StringClass = Glu.glass.register({
       return rex.match(char, "^[A-Z]$") ~= nil
     end
 
+    --- Determines whether a single character is a lowercase letter.
+    ---
+    ---@param char string The single character to test.
+    ---@returns boolean True if the character is a lowercase letter (a-z).
+    ---@example
+    --- ```lua
+    --- string.is_lowercase("a")
+    --- -- true
+    --- ```
     function self.is_lowercase(char)
       ___.v.type(char, "string", 1, false)
       ___.v.test(#char == 1, "Expected a single character", 1)
@@ -448,6 +513,16 @@ local StringClass = Glu.glass.register({
       return rex.match(char, "^[a-z]$") ~= nil
     end
 
+    --- Splits a string into a table of alternating text and numeric chunks, where
+    --- consecutive digits are grouped together and converted to numbers.
+    ---
+    ---@param str string The string to split.
+    ---@returns table A table of string and number chunks in their original order.
+    ---@example
+    --- ```lua
+    --- string.split_natural("file42name")
+    --- -- { "file", 42, "name" }
+    --- ```
     function self.split_natural(str)
       ___.v.type(str, "string", 1, false)
 
@@ -485,6 +560,17 @@ local StringClass = Glu.glass.register({
       return result
     end
 
+    --- Compares two strings using natural sort order, treating embedded numbers
+    --- as numeric values rather than character sequences.
+    ---
+    ---@param a string The first string to compare.
+    ---@param b string The second string to compare.
+    ---@returns boolean True if `a` sorts before `b` in natural order.
+    ---@example
+    --- ```lua
+    --- string.natural_compare("item2", "item10")
+    --- -- true
+    --- ```
     function self.natural_compare(a, b)
       local a_parts = self.split_natural(a)
       local b_parts = self.split_natural(b)
@@ -515,6 +601,16 @@ local StringClass = Glu.glass.register({
       return #a_parts < #b_parts
     end
 
+    --- Finds the position of the first match of a pattern within a string.
+    ---
+    ---@param str string The string to search within.
+    ---@param pattern string The pattern to search for.
+    ---@returns number|nil The starting index of the first match, or nil if not found.
+    ---@example
+    --- ```lua
+    --- string.index_of("hello world", "world")
+    --- -- 7
+    --- ```
     function self.index_of(str, pattern)
       ___.v.type(str, "string", 1, false)
       ___.v.type(pattern, "string", 2, false)

--- a/src/scripts/string.lua
+++ b/src/scripts/string.lua
@@ -6,7 +6,7 @@ local StringClass = Glu.glass.register({
     --- Capitalizes the first character of a string.
     ---
     ---@param str string The string to capitalize.
-    ---@returns string The capitalized string.
+    ---@return string result The capitalized string.
     ---@example
     --- ```lua
     --- string.capitalize("hello")
@@ -23,7 +23,7 @@ local StringClass = Glu.glass.register({
     --- Trims whitespace from the beginning and end of a string.
     ---
     ---@param str string The string to trim.
-    ---@returns string The trimmed string.
+    ---@return string trimmed The trimmed string.
     ---@example
     --- ```lua
     --- string.trim("  hello  ")
@@ -37,7 +37,7 @@ local StringClass = Glu.glass.register({
     --- Trims whitespace from the left side of a string.
     ---
     ---@param str string The string to trim.
-    ---@returns string The trimmed string.
+    ---@return string trimmed The trimmed string.
     ---@example
     --- ```lua
     --- string.ltrim("  hello  ")
@@ -51,7 +51,7 @@ local StringClass = Glu.glass.register({
     --- Trims whitespace from the right side of a string.
     ---
     ---@param str string The string to trim.
-    ---@returns string The trimmed string.
+    ---@return string trimmed The trimmed string.
     ---@example
     --- ```lua
     --- string.rtrim("  hello  ")
@@ -65,7 +65,7 @@ local StringClass = Glu.glass.register({
     --- Strips line breaks from a string.
     ---
     ---@param str string The string to strip line breaks from.
-    ---@returns string The string with line breaks removed.
+    ---@return string result The string with line breaks removed.
     ---@example
     --- ```lua
     --- string.strip_linebreaks("hello\nworld")
@@ -82,7 +82,7 @@ local StringClass = Glu.glass.register({
     ---@param str string The string to replace occurrences in.
     ---@param pattern string The pattern to replace.
     ---@param replacement string The replacement string.
-    ---@returns string The string with occurrences replaced.
+    ---@return string str The string with occurrences replaced.
     ---@example
     --- ```lua
     --- string.replace("hello world", "o", "a")
@@ -106,7 +106,7 @@ local StringClass = Glu.glass.register({
     ---
     ---@param str string The string to split.
     ---@param delimiter string The regex delimiter to split the string by.
-    ---@returns table The split string.
+    ---@return table parts The split string.
     ---@example
     --- ```lua
     --- string.split("hello world")
@@ -140,7 +140,7 @@ local StringClass = Glu.glass.register({
     ---
     ---@param input string The string to walk over.
     ---@param delimiter string The regex delimiter to split the string by.
-    ---@returns function The iterator function.
+    ---@return function iterator The iterator function.
     ---@example
     --- ```lua
     --- for i, part in string.walk("hello world") do
@@ -172,7 +172,7 @@ local StringClass = Glu.glass.register({
     ---@param number string|number The number to format (number or string)
     ---@param thousands string The thousands separator (optional, defaults to ",")
     ---@param decimal string The decimal separator (optional, defaults to ".")
-    ---@returns string The formatted number
+    ---@return string formatted The formatted number
     function self.format_number(number, thousands, decimal)
       ___.v.type(number, "number|string", 1, false)
       ___.v.type(thousands, "string", 2, true)
@@ -219,7 +219,7 @@ local StringClass = Glu.glass.register({
     ---@param str string The formatted number string.
     ---@param thousands string The thousands separator (optional, defaults to ",").
     ---@param decimal string The decimal separator (optional, defaults to ".").
-    ---@returns number The parsed number.
+    ---@return number number The parsed number.
     ---@example
     --- ```lua
     --- string.parse_formatted_number("1,234,567.89")
@@ -250,7 +250,7 @@ local StringClass = Glu.glass.register({
     ---
     ---@param str string The string to check.
     ---@param start string The pattern to check for.
-    ---@returns boolean Whether the string starts with the pattern.
+    ---@return boolean matched Whether the string starts with the pattern.
     ---@example
     --- ```lua
     --- string.starts_with("hello world", "hello")
@@ -270,7 +270,7 @@ local StringClass = Glu.glass.register({
     ---
     ---@param str string The string to check.
     ---@param ending string The pattern to check for.
-    ---@returns boolean Whether the string ends with the pattern.
+    ---@return boolean matched Whether the string ends with the pattern.
     ---@example
     --- ```lua
     --- string.ends_with("hello world", "world")
@@ -291,7 +291,7 @@ local StringClass = Glu.glass.register({
     ---
     ---@param str string The string to check.
     ---@param pattern string The pattern to check for.
-    ---@returns boolean Whether the string contains the pattern.
+    ---@return boolean matched Whether the string contains the pattern.
     ---@example
     --- ```lua
     --- string.contains("hello world", "world")
@@ -310,7 +310,7 @@ local StringClass = Glu.glass.register({
     ---
     ---@param str string The string to append to.
     ---@param suffix string The suffix to append.
-    ---@returns string The string with the suffix appended.
+    ---@return string result The string with the suffix appended.
     ---@example
     --- ```lua
     --- string.append("hello", " world")
@@ -327,7 +327,7 @@ local StringClass = Glu.glass.register({
     ---
     ---@param str string The string to prepend to.
     ---@param prefix string The prefix to prepend.
-    ---@returns string The string with the prefix prepended.
+    ---@return string result The string with the prefix prepended.
     ---@example
     --- ```lua
     --- string.prepend("world", "hello ")
@@ -345,8 +345,8 @@ local StringClass = Glu.glass.register({
     ---@param patterns table The patterns to search for
     ---@param tokens table The tokens to replace the patterns with
     ---@param default_token string The default token to use if no pattern is found (optional, defaults to "")
-    ---@returns table A table of match results.
-    ---@returns table The list of replacement tokens.
+    ---@return table results A table of match results.
+    ---@return table token_list The list of replacement tokens.
     ---@example
     --- ```lua
     --- string.reg_assoc("hello world", {"hello", "world"}, {"foo", "bar"})
@@ -403,7 +403,7 @@ local StringClass = Glu.glass.register({
     --- Determines whether a single character is an alphabetic letter.
     ---
     ---@param char string The single character to test.
-    ---@returns boolean True if the character is a letter (a-z, A-Z).
+    ---@return boolean is_alpha True if the character is a letter (a-z, A-Z).
     ---@example
     --- ```lua
     --- string.is_alpha("a")
@@ -419,7 +419,7 @@ local StringClass = Glu.glass.register({
     --- Determines whether a single character is a numeric digit.
     ---
     ---@param char string The single character to test.
-    ---@returns boolean True if the character is a digit (0-9).
+    ---@return boolean is_numeric True if the character is a digit (0-9).
     ---@example
     --- ```lua
     --- string.is_numeric("5")
@@ -435,7 +435,7 @@ local StringClass = Glu.glass.register({
     --- Determines whether a single character is alphanumeric.
     ---
     ---@param char string The single character to test.
-    ---@returns boolean True if the character is a letter or digit (a-z, A-Z, 0-9).
+    ---@return boolean is_alphanumeric True if the character is a letter or digit (a-z, A-Z, 0-9).
     ---@example
     --- ```lua
     --- string.is_alphanumeric("a")
@@ -451,7 +451,7 @@ local StringClass = Glu.glass.register({
     --- Determines whether a single character is a whitespace character.
     ---
     ---@param char string The single character to test.
-    ---@returns boolean True if the character is whitespace.
+    ---@return boolean is_whitespace True if the character is whitespace.
     ---@example
     --- ```lua
     --- string.is_whitespace(" ")
@@ -468,7 +468,7 @@ local StringClass = Glu.glass.register({
     --- it is neither alphanumeric nor whitespace.
     ---
     ---@param char string The single character to test.
-    ---@returns boolean True if the character is punctuation.
+    ---@return boolean is_punctuation True if the character is punctuation.
     ---@example
     --- ```lua
     --- string.is_punctuation("!")
@@ -484,7 +484,7 @@ local StringClass = Glu.glass.register({
     --- Determines whether a single character is an uppercase letter.
     ---
     ---@param char string The single character to test.
-    ---@returns boolean True if the character is an uppercase letter (A-Z).
+    ---@return boolean is_uppercase True if the character is an uppercase letter (A-Z).
     ---@example
     --- ```lua
     --- string.is_uppercase("A")
@@ -500,7 +500,7 @@ local StringClass = Glu.glass.register({
     --- Determines whether a single character is a lowercase letter.
     ---
     ---@param char string The single character to test.
-    ---@returns boolean True if the character is a lowercase letter (a-z).
+    ---@return boolean is_lowercase True if the character is a lowercase letter (a-z).
     ---@example
     --- ```lua
     --- string.is_lowercase("a")
@@ -517,7 +517,7 @@ local StringClass = Glu.glass.register({
     --- consecutive digits are grouped together and converted to numbers.
     ---
     ---@param str string The string to split.
-    ---@returns table A table of string and number chunks in their original order.
+    ---@return table result A table of string and number chunks in their original order.
     ---@example
     --- ```lua
     --- string.split_natural("file42name")
@@ -565,7 +565,7 @@ local StringClass = Glu.glass.register({
     ---
     ---@param a string The first string to compare.
     ---@param b string The second string to compare.
-    ---@returns boolean True if `a` sorts before `b` in natural order.
+    ---@return boolean is_before True if `a` sorts before `b` in natural order.
     ---@example
     --- ```lua
     --- string.natural_compare("item2", "item10")
@@ -605,7 +605,7 @@ local StringClass = Glu.glass.register({
     ---
     ---@param str string The string to search within.
     ---@param pattern string The pattern to search for.
-    ---@returns number|nil The starting index of the first match, or nil if not found.
+    ---@return number|nil index The starting index of the first match, or nil if not found.
     ---@example
     --- ```lua
     --- string.index_of("hello world", "world")

--- a/src/scripts/table.lua
+++ b/src/scripts/table.lua
@@ -3,6 +3,17 @@ local TableClass = Glu.glass.register({
   class_name = "TableClass",
   dependencies = {},
   setup = function(___, self)
+    --- Casts the given value(s) into an indexed table. If a single indexed
+    --- table is passed, it is returned unchanged; otherwise the arguments are
+    --- collected into a new table.
+    ---
+    ---@param ... any The value(s) to cast into an indexed table.
+    ---@returns table The resulting indexed table.
+    ---@example
+    --- ```lua
+    --- table.n_cast(1, 2, 3)
+    --- -- {1, 2, 3}
+    --- ```
     function self.n_cast(...)
       if type(...) == "table" and self.indexed(...) then
         return ...
@@ -13,6 +24,18 @@ local TableClass = Glu.glass.register({
 
     self.assure_indexed = self.n_cast
 
+    --- Maps each element of a table to a new value using the provided function,
+    --- preserving the original keys.
+    ---
+    ---@param t table The table to map over.
+    ---@param fn function The function called as fn(key, value, ...) for each element.
+    ---@param ... any Additional arguments passed to the mapping function.
+    ---@returns table A new table with the mapped values.
+    ---@example
+    --- ```lua
+    --- table.map({1, 2, 3}, function(k, v) return v * 2 end)
+    --- -- {2, 4, 6}
+    --- ```
     function self.map(t, fn, ...)
       ___.v.type(t, "table", 1, false)
       ___.v.type(fn, "function", 2, false)
@@ -24,6 +47,16 @@ local TableClass = Glu.glass.register({
       return result
     end
 
+    --- Returns an indexed table containing the values of the given table,
+    --- discarding the keys.
+    ---
+    ---@param t table The table whose values to collect.
+    ---@returns table An indexed table of the values.
+    ---@example
+    --- ```lua
+    --- table.values({a = 1, b = 2})
+    --- -- {1, 2}
+    --- ```
     function self.values(t)
       ___.v.type(t, "table", 1, false)
 
@@ -34,6 +67,17 @@ local TableClass = Glu.glass.register({
       return result
     end
 
+    --- Determines whether all elements of an indexed table are of the same
+    --- type.
+    ---
+    ---@param t table The indexed table to check.
+    ---@param typ string|nil The type to check against. (Optional. Default is the type of the first element.)
+    ---@returns boolean True if all elements are of the given type, otherwise false.
+    ---@example
+    --- ```lua
+    --- table.n_uniform({1, 2, 3})
+    --- -- true
+    --- ```
     function self.n_uniform(t, typ)
       ___.v.type(t, "table", 1, false)
       ___.v.indexed(t, 1, false)
@@ -50,6 +94,16 @@ local TableClass = Glu.glass.register({
       return true
     end
 
+    --- Returns a new indexed table containing only the distinct values of the
+    --- given indexed table, preserving their first-seen order.
+    ---
+    ---@param t table The indexed table to deduplicate.
+    ---@returns table A new indexed table of distinct values.
+    ---@example
+    --- ```lua
+    --- table.n_distinct({1, 2, 2, 3, 3, 3})
+    --- -- {1, 2, 3}
+    --- ```
     function self.n_distinct(t)
       ___.v.indexed(t, 1, false)
 
@@ -63,12 +117,31 @@ local TableClass = Glu.glass.register({
       return result
     end
 
+    --- Removes and returns the last element of an indexed table.
+    ---
+    ---@param t table The indexed table to pop from.
+    ---@returns any The removed last element.
+    ---@example
+    --- ```lua
+    --- table.pop({1, 2, 3})
+    --- -- 3
+    --- ```
     function self.pop(t)
       ___.v.type(t, "table", 1, false)
       ___.v.indexed(t, 1, false)
       return table.remove(t, #t)
     end
 
+    --- Appends a value to the end of an indexed table.
+    ---
+    ---@param t table The indexed table to push onto.
+    ---@param v any The value to append.
+    ---@returns number The new length of the table.
+    ---@example
+    --- ```lua
+    --- table.push({1, 2}, 3)
+    --- -- 3
+    --- ```
     function self.push(t, v)
       ___.v.type(t, "table", 1, false)
       ___.v.type(v, "any", 2, false)
@@ -78,6 +151,17 @@ local TableClass = Glu.glass.register({
       return #t
     end
 
+    --- Inserts a value at the beginning of an indexed table, shifting the
+    --- existing elements up.
+    ---
+    ---@param t table The indexed table to unshift onto.
+    ---@param v any The value to insert at the front.
+    ---@returns number The new length of the table.
+    ---@example
+    --- ```lua
+    --- table.unshift({2, 3}, 1)
+    --- -- 3
+    --- ```
     function self.unshift(t, v)
       ___.v.type(t, "table", 1, false)
       ___.v.type(v, "any", 2, false)
@@ -87,12 +171,34 @@ local TableClass = Glu.glass.register({
       return #t
     end
 
+    --- Removes and returns the first element of an indexed table, shifting the
+    --- remaining elements down.
+    ---
+    ---@param t table The indexed table to shift from.
+    ---@returns any The removed first element.
+    ---@example
+    --- ```lua
+    --- table.shift({1, 2, 3})
+    --- -- 1
+    --- ```
     function self.shift(t)
       ___.v.type(t, "table", 1, false)
       ___.v.indexed(t, 1, false)
       return table.remove(t, 1)
     end
 
+    --- Builds an associative table using the values of source as keys. The
+    --- value for each key is taken from a parallel spec table, computed by a
+    --- spec function, or set to a constant spec value.
+    ---
+    ---@param source table An indexed, non-empty table whose values become the keys.
+    ---@param spec any A parallel indexed table, a function called as spec(index, key), or a constant value.
+    ---@returns table The resulting associative table.
+    ---@example
+    --- ```lua
+    --- table.allocate({"a", "b"}, {1, 2})
+    --- -- {a = 1, b = 2}
+    --- ```
     function self.allocate(source, spec)
       local spec_type = type(spec)
       ___.v.type(source, "table", 1, false)
@@ -124,6 +230,16 @@ local TableClass = Glu.glass.register({
       return result
     end
 
+    --- Determines whether a table is indexed, meaning its keys are sequential
+    --- integers starting at 1.
+    ---
+    ---@param t table The table to check.
+    ---@returns boolean True if the table is indexed, otherwise false.
+    ---@example
+    --- ```lua
+    --- table.indexed({1, 2, 3})
+    --- -- true
+    --- ```
     function self.indexed(t)
       ___.v.type(t, "table", 1, false)
 
@@ -137,6 +253,16 @@ local TableClass = Glu.glass.register({
       return true
     end
 
+    --- Determines whether a table is associative, meaning it has at least one
+    --- key that is not a positive integer.
+    ---
+    ---@param t table The table to check.
+    ---@returns boolean True if the table is associative, otherwise false.
+    ---@example
+    --- ```lua
+    --- table.associative({a = 1})
+    --- -- true
+    --- ```
     function self.associative(t)
       ___.v.type(t, "table", 1, false)
 
@@ -148,6 +274,18 @@ local TableClass = Glu.glass.register({
       return false
     end
 
+    --- Reduces a table to a single value by iteratively applying a function to
+    --- an accumulator and each element.
+    ---
+    ---@param t table The indexed table to reduce.
+    ---@param fn function The reducer called as fn(accumulator, value, key).
+    ---@param initial any The initial value of the accumulator.
+    ---@returns any The final accumulated value.
+    ---@example
+    --- ```lua
+    --- table.reduce({1, 2, 3}, function(acc, v) return acc + v end, 0)
+    --- -- 6
+    --- ```
     function self.reduce(t, fn, initial)
       ___.v.indexed(t, 1, false)
       ___.v.type(fn, "function", 2, false)
@@ -160,6 +298,18 @@ local TableClass = Glu.glass.register({
       return acc
     end
 
+    --- Returns a new indexed table containing the elements from start to stop,
+    --- inclusive.
+    ---
+    ---@param t table The indexed table to slice.
+    ---@param start number The starting index (1-based).
+    ---@param stop number|nil The ending index. (Optional. Default is the length of the table.)
+    ---@returns table A new indexed table with the sliced elements.
+    ---@example
+    --- ```lua
+    --- table.slice({1, 2, 3, 4}, 2, 3)
+    --- -- {2, 3}
+    --- ```
     function self.slice(t, start, stop)
       ___.v.indexed(t, 1, false)
       ___.v.type(start, "number", 2, false)
@@ -179,6 +329,19 @@ local TableClass = Glu.glass.register({
       return result
     end
 
+    --- Removes a range of elements from an indexed table in place, returning the
+    --- modified table and the removed elements.
+    ---
+    ---@param t table The indexed table to remove from.
+    ---@param start number The starting index (1-based) of the range to remove.
+    ---@param stop number|nil The ending index of the range. (Optional. Default is start.)
+    ---@returns table The modified table with the range removed.
+    ---@returns table An indexed table of the removed elements.
+    ---@example
+    --- ```lua
+    --- table.remove({1, 2, 3, 4}, 2, 3)
+    --- -- {1, 4}, {2, 3}
+    --- ```
     function self.remove(t, start, stop)
       ___.v.indexed(t, 1, false)
       ___.v.type(start, "number", 2, false)
@@ -196,6 +359,17 @@ local TableClass = Glu.glass.register({
       return t, snipped
     end
 
+    --- Splits an indexed table into a table of smaller indexed tables, each of
+    --- the given size (the final chunk may be smaller).
+    ---
+    ---@param t table The indexed table to chunk.
+    ---@param size number The maximum size of each chunk.
+    ---@returns table A table of chunk tables.
+    ---@example
+    --- ```lua
+    --- table.chunk({1, 2, 3, 4, 5}, 2)
+    --- -- {{1, 2}, {3, 4}, {5}}
+    --- ```
     function self.chunk(t, size)
       ___.v.indexed(t, 1, false)
       ___.v.type(size, "number", 2, false)
@@ -207,6 +381,17 @@ local TableClass = Glu.glass.register({
       return result
     end
 
+    --- Appends the given values to an indexed table in place. Table arguments
+    --- are flattened one level, with their elements appended individually.
+    ---
+    ---@param tbl table The indexed table to append to.
+    ---@param ... any The values or tables to append.
+    ---@returns table The modified table.
+    ---@example
+    --- ```lua
+    --- table.concat({1, 2}, {3, 4}, 5)
+    --- -- {1, 2, 3, 4, 5}
+    --- ```
     function self.concat(tbl, ...)
       ___.v.indexed(tbl, 1, false)
 
@@ -225,6 +410,16 @@ local TableClass = Glu.glass.register({
       return tbl
     end
 
+    --- Returns a new indexed table with the first n elements removed.
+    ---
+    ---@param tbl table The indexed table to drop from.
+    ---@param n number The number of elements to drop from the start.
+    ---@returns table A new indexed table without the first n elements.
+    ---@example
+    --- ```lua
+    --- table.drop({1, 2, 3, 4}, 2)
+    --- -- {3, 4}
+    --- ```
     function self.drop(tbl, n)
       ___.v.indexed(tbl, 1, false)
       ___.v.type(n, "number", 2, false)
@@ -232,6 +427,16 @@ local TableClass = Glu.glass.register({
       return self.slice(tbl, n + 1)
     end
 
+    --- Returns a new indexed table with the last n elements removed.
+    ---
+    ---@param tbl table The indexed table to drop from.
+    ---@param n number The number of elements to drop from the end.
+    ---@returns table A new indexed table without the last n elements.
+    ---@example
+    --- ```lua
+    --- table.drop_right({1, 2, 3, 4}, 2)
+    --- -- {1, 2}
+    --- ```
     function self.drop_right(tbl, n)
       ___.v.indexed(tbl, 1, false)
       ___.v.type(n, "number", 2, false)
@@ -239,6 +444,18 @@ local TableClass = Glu.glass.register({
       return self.slice(tbl, 1, #tbl - n)
     end
 
+    --- Fills a range of an indexed table in place with the given value.
+    ---
+    ---@param tbl table The indexed table to fill.
+    ---@param value any The value to fill with.
+    ---@param start number|nil The starting index of the range. (Optional. Default is 1.)
+    ---@param stop number|nil The ending index of the range. (Optional. Default is the length of the table.)
+    ---@returns table The modified table.
+    ---@example
+    --- ```lua
+    --- table.fill({1, 2, 3, 4}, 0, 2, 3)
+    --- -- {1, 0, 0, 4}
+    --- ```
     function self.fill(tbl, value, start, stop)
       ___.v.indexed(tbl, 1, false)
       ___.v.type(value, "any", 2, false)
@@ -253,6 +470,17 @@ local TableClass = Glu.glass.register({
       return tbl
     end
 
+    --- Returns the index of the first element for which the predicate returns
+    --- true, or nil if none match.
+    ---
+    ---@param tbl table The indexed table to search.
+    ---@param fn function The predicate called as fn(index, value).
+    ---@returns number|nil The index of the first matching element, or nil.
+    ---@example
+    --- ```lua
+    --- table.find({1, 2, 3}, function(i, v) return v == 2 end)
+    --- -- 2
+    --- ```
     function self.find(tbl, fn)
       ___.v.indexed(tbl, 1, false)
       ___.v.type(fn, "function", 2, false)
@@ -265,6 +493,17 @@ local TableClass = Glu.glass.register({
       return nil
     end
 
+    --- Returns the index of the last element for which the predicate returns
+    --- true, or nil if none match.
+    ---
+    ---@param tbl table The indexed table to search.
+    ---@param fn function The predicate called as fn(index, value).
+    ---@returns number|nil The index of the last matching element, or nil.
+    ---@example
+    --- ```lua
+    --- table.find_last({1, 2, 2, 3}, function(i, v) return v == 2 end)
+    --- -- 3
+    --- ```
     function self.find_last(tbl, fn)
       ___.v.indexed(tbl, 1, false)
       ___.v.type(fn, "function", 2, false)
@@ -277,6 +516,16 @@ local TableClass = Glu.glass.register({
       return nil
     end
 
+    --- Flattens an indexed table by one level, expanding any nested tables into
+    --- the result.
+    ---
+    ---@param tbl table The indexed table to flatten.
+    ---@returns table A new indexed table flattened one level.
+    ---@example
+    --- ```lua
+    --- table.flatten({1, {2, 3}, 4})
+    --- -- {1, 2, 3, 4}
+    --- ```
     function self.flatten(tbl)
       ___.v.indexed(tbl, 1, false)
 
@@ -292,6 +541,16 @@ local TableClass = Glu.glass.register({
       return result
     end
 
+    --- Recursively flattens an indexed table, expanding all nested tables at any
+    --- depth into the result.
+    ---
+    ---@param tbl table The indexed table to flatten.
+    ---@returns table A new fully flattened indexed table.
+    ---@example
+    --- ```lua
+    --- table.flatten_deeply({1, {2, {3, 4}}})
+    --- -- {1, 2, 3, 4}
+    --- ```
     function self.flatten_deeply(tbl)
       ___.v.indexed(tbl, 1, false)
 
@@ -307,12 +566,32 @@ local TableClass = Glu.glass.register({
       return result
     end
 
+    --- Returns a new indexed table containing all but the last element.
+    ---
+    ---@param tbl table The indexed table to take the initial elements from.
+    ---@returns table A new indexed table without the last element.
+    ---@example
+    --- ```lua
+    --- table.initial({1, 2, 3})
+    --- -- {1, 2}
+    --- ```
     function self.initial(tbl)
       ___.v.indexed(tbl, 1, false)
       if #tbl <= 1 then return {} end
       return self.slice(tbl, 1, #tbl - 1)
     end
 
+    --- Removes all occurrences of the given values from an indexed table in
+    --- place.
+    ---
+    ---@param tbl table The indexed table to pull values from.
+    ---@param ... any The values to remove.
+    ---@returns table The modified table.
+    ---@example
+    --- ```lua
+    --- table.pull({1, 2, 3, 2, 1}, 2)
+    --- -- {1, 3, 1}
+    --- ```
     function self.pull(tbl, ...)
       ___.v.indexed(tbl, 1, false)
 
@@ -333,6 +612,15 @@ local TableClass = Glu.glass.register({
       return tbl
     end
 
+    --- Reverses the order of the elements of an indexed table in place.
+    ---
+    ---@param tbl table The indexed table to reverse.
+    ---@returns table The reversed table.
+    ---@example
+    --- ```lua
+    --- table.reverse({1, 2, 3})
+    --- -- {3, 2, 1}
+    --- ```
     function self.reverse(tbl)
       ___.v.indexed(tbl, 1, false)
 
@@ -343,6 +631,16 @@ local TableClass = Glu.glass.register({
       return tbl
     end
 
+    --- Removes duplicate values from an indexed table in place, keeping the
+    --- first occurrence of each value.
+    ---
+    ---@param tbl table The indexed table to deduplicate.
+    ---@returns table The modified table with duplicates removed.
+    ---@example
+    --- ```lua
+    --- table.uniq({1, 2, 2, 3, 1})
+    --- -- {1, 2, 3}
+    --- ```
     function self.uniq(tbl)
       ___.v.indexed(tbl, 1, false)
 
@@ -366,6 +664,16 @@ local TableClass = Glu.glass.register({
       return tbl
     end
 
+    --- Unzips a table of equal-length sub-tables, regrouping their elements by
+    --- position into new sub-tables.
+    ---
+    ---@param tbl table An indexed table of equal-length indexed sub-tables.
+    ---@returns table A new table of sub-tables grouped by position.
+    ---@example
+    --- ```lua
+    --- table.unzip({{1, "a"}, {2, "b"}})
+    --- -- {{1, 2}, {"a", "b"}}
+    --- ```
     function self.unzip(tbl)
       ___.v.indexed(tbl, 1, false)
 
@@ -391,6 +699,15 @@ local TableClass = Glu.glass.register({
       return result
     end
 
+    --- Creates a new table with weak references, controlled by the given mode.
+    ---
+    ---@param opt string|nil The weak mode: "k", "v", or "kv". (Optional. Default is "v".)
+    ---@returns table A new table with the specified weak mode.
+    ---@example
+    --- ```lua
+    --- table.new_weak("kv")
+    --- -- a table with weak keys and values
+    --- ```
     function self.new_weak(opt)
       opt = opt or "v"
       ___.v.test(rex.match(opt, "^(k?v?|v?k?)$"), opt, 1, false)
@@ -398,12 +715,31 @@ local TableClass = Glu.glass.register({
       return setmetatable({}, { __mode = opt })
     end
 
+    --- Determines whether a table holds weak references.
+    ---
+    ---@param tbl table The table to check.
+    ---@returns boolean True if the table has a weak mode set, otherwise false.
+    ---@example
+    --- ```lua
+    --- table.weak(table.new_weak("v"))
+    --- -- true
+    --- ```
     function self.weak(tbl)
       ___.v.type(tbl, "table", 1, false)
       local mt = getmetatable(tbl)
       return mt ~= nil and mt.__mode ~= nil
     end
 
+    --- Zips multiple equal-length indexed tables together, grouping elements at
+    --- the same position into new sub-tables.
+    ---
+    ---@param ... table The equal-length indexed tables to zip.
+    ---@returns table A new table of position-grouped sub-tables.
+    ---@example
+    --- ```lua
+    --- table.zip({1, 2}, {"a", "b"})
+    --- -- {{1, "a"}, {2, "b"}}
+    --- ```
     function self.zip(...)
       local tbls = { ... }
       local results = {}
@@ -420,6 +756,16 @@ local TableClass = Glu.glass.register({
       return results
     end
 
+    --- Determines whether an indexed table contains the given value.
+    ---
+    ---@param tbl table The indexed table to search.
+    ---@param value any The value to look for.
+    ---@returns boolean True if the value is present, otherwise false.
+    ---@example
+    --- ```lua
+    --- table.includes({1, 2, 3}, 2)
+    --- -- true
+    --- ```
     function self.includes(tbl, value)
       ___.v.indexed(tbl, 1, false)
       ___.v.type(value, "any", 2, false)
@@ -481,6 +827,17 @@ local TableClass = Glu.glass.register({
       return result
     end
 
+    --- Returns the names of all function-valued keys of an object table,
+    --- optionally including those inherited through its metatable chain.
+    ---
+    ---@param tbl table The object table to inspect.
+    ---@param extending boolean|nil Whether to include inherited functions. (Optional. Default is false.)
+    ---@returns table An indexed table of function names.
+    ---@example
+    --- ```lua
+    --- table.functions(myObject)
+    --- -- {"method_a", "method_b"}
+    --- ```
     function self.functions(tbl, extending)
       ___.v.object(tbl, 1, false)
       ___.v.type(extending, "boolean", 2, true)
@@ -493,6 +850,17 @@ local TableClass = Glu.glass.register({
     -- Alias for functions
     self.methods = self.functions
 
+    --- Returns the names of all non-function keys of an object table, optionally
+    --- including those inherited through its metatable chain.
+    ---
+    ---@param tbl table The object table to inspect.
+    ---@param extending boolean|nil Whether to include inherited properties. (Optional. Default is false.)
+    ---@returns table An indexed table of property names.
+    ---@example
+    --- ```lua
+    --- table.properties(myObject)
+    --- -- {"name", "value"}
+    --- ```
     function self.properties(tbl, extending)
       ___.v.object(tbl, 1, false)
       ___.v.type(extending, "boolean", 2, true)
@@ -503,11 +871,32 @@ local TableClass = Glu.glass.register({
       return assemble_results(tables, test)
     end
 
+    --- Determines whether a table is an object, identified by an `object` field
+    --- set to true.
+    ---
+    ---@param tbl table The table to check.
+    ---@returns boolean True if the table is an object, otherwise false.
+    ---@example
+    --- ```lua
+    --- table.object({object = true})
+    --- -- true
+    --- ```
     function self.object(tbl)
       ___.v.type(tbl, "table", 1, false)
       return tbl.object == true
     end
 
+    --- Merges the key-value pairs of one associative table into another in
+    --- place, overwriting existing keys.
+    ---
+    ---@param tbl table The associative table to merge into.
+    ---@param value table The associative table whose pairs are copied in.
+    ---@returns table The modified table.
+    ---@example
+    --- ```lua
+    --- table.add({a = 1}, {b = 2})
+    --- -- {a = 1, b = 2}
+    --- ```
     function self.add(tbl, value)
       ___.v.associative(tbl, 1, false)
       ___.v.associative(value, 2, false)
@@ -519,6 +908,18 @@ local TableClass = Glu.glass.register({
       return tbl
     end
 
+    --- Inserts the elements of one indexed table into another at the given
+    --- index, in place.
+    ---
+    ---@param tbl1 table The indexed table to insert into.
+    ---@param tbl2 table The indexed table whose elements are inserted.
+    ---@param index number|nil The position at which to insert. (Optional. Default is the end of tbl1.)
+    ---@returns table The modified table.
+    ---@example
+    --- ```lua
+    --- table.n_add({1, 4}, {2, 3}, 2)
+    --- -- {1, 2, 3, 4}
+    --- ```
     function self.n_add(tbl1, tbl2, index)
       ___.v.indexed(tbl1, 1, false)
       ___.v.indexed(tbl2, 2, false)
@@ -535,6 +936,17 @@ local TableClass = Glu.glass.register({
       return tbl1
     end
 
+    --- Returns a stateful iterator function that walks the elements of an
+    --- indexed table, yielding each index and value.
+    ---
+    ---@param tbl table The indexed table to walk.
+    ---@returns function An iterator returning index and value on each call.
+    ---@example
+    --- ```lua
+    --- for i, v in table.walk({"a", "b"}) do print(i, v) end
+    --- -- 1 a
+    --- -- 2 b
+    --- ```
     function self.walk(tbl)
       ___.v.indexed(tbl, 1, false)
 
@@ -545,6 +957,15 @@ local TableClass = Glu.glass.register({
       end
     end
 
+    --- Returns a uniformly random element from an indexed table.
+    ---
+    ---@param list table The indexed table to choose from.
+    ---@returns any A randomly chosen element.
+    ---@example
+    --- ```lua
+    --- table.element_of({"a", "b", "c"})
+    --- -- "b"
+    --- ```
     function self.element_of(list)
       ___.v.type(list, "table", 1, false)
 
@@ -552,6 +973,16 @@ local TableClass = Glu.glass.register({
       return list[math.random(max)]
     end
 
+    --- Returns a randomly chosen key from an associative table, where each
+    --- value is the relative weight of its key.
+    ---
+    ---@param list table An associative table mapping keys to numeric weights.
+    ---@returns any A randomly chosen key, weighted by its value.
+    ---@example
+    --- ```lua
+    --- table.element_of_weighted({common = 90, rare = 10})
+    --- -- "common"
+    --- ```
     function self.element_of_weighted(list)
       ___.v.type(list, "table", 1, false)
 
@@ -578,6 +1009,17 @@ local TableClass = Glu.glass.register({
       return condition
     end
 
+    --- Determines whether all elements of an indexed table satisfy the
+    --- condition. The condition may be a predicate function or a value to match.
+    ---
+    ---@param tbl table The indexed table to test.
+    ---@param condition any A predicate function or a value to compare each element against.
+    ---@returns boolean True if every element satisfies the condition, otherwise false.
+    ---@example
+    --- ```lua
+    --- table.all({2, 4, 6}, function(v) return v % 2 == 0 end)
+    --- -- true
+    --- ```
     function self.all(tbl, condition)
       ___.v.indexed(tbl, 1, false)
       ___.v.type(condition, "any", 2, false)
@@ -594,6 +1036,17 @@ local TableClass = Glu.glass.register({
       return count == #tbl
     end
 
+    --- Determines whether at least one element of an indexed table satisfies the
+    --- condition. The condition may be a predicate function or a value to match.
+    ---
+    ---@param tbl table The indexed table to test.
+    ---@param condition any A predicate function or a value to compare each element against.
+    ---@returns boolean True if any element satisfies the condition, otherwise false.
+    ---@example
+    --- ```lua
+    --- table.some({1, 2, 3}, 2)
+    --- -- true
+    --- ```
     function self.some(tbl, condition)
       ___.v.indexed(tbl, 1, false)
       ___.v.type(condition, "any", 2, false)
@@ -603,6 +1056,17 @@ local TableClass = Glu.glass.register({
       return #table.n_filter(tbl, condition) > 0
     end
 
+    --- Determines whether no element of an indexed table satisfies the
+    --- condition. The condition may be a predicate function or a value to match.
+    ---
+    ---@param tbl table The indexed table to test.
+    ---@param condition any A predicate function or a value to compare each element against.
+    ---@returns boolean True if no element satisfies the condition, otherwise false.
+    ---@example
+    --- ```lua
+    --- table.none({1, 3, 5}, function(v) return v % 2 == 0 end)
+    --- -- true
+    --- ```
     function self.none(tbl, condition)
       ___.v.indexed(tbl, 1, false)
       ___.v.type(condition, "any", 2, false)
@@ -612,6 +1076,17 @@ local TableClass = Glu.glass.register({
       return #table.n_filter(tbl, condition) == 0
     end
 
+    --- Determines whether exactly one element of an indexed table satisfies the
+    --- condition. The condition may be a predicate function or a value to match.
+    ---
+    ---@param tbl table The indexed table to test.
+    ---@param condition any A predicate function or a value to compare each element against.
+    ---@returns boolean True if exactly one element satisfies the condition, otherwise false.
+    ---@example
+    --- ```lua
+    --- table.one({1, 2, 3}, 2)
+    --- -- true
+    --- ```
     function self.one(tbl, condition)
       ___.v.indexed(tbl, 1, false)
       ___.v.type(condition, "any", 2, false)
@@ -621,6 +1096,17 @@ local TableClass = Glu.glass.register({
       return #table.n_filter(tbl, condition) == 1
     end
 
+    --- Counts how many elements of an indexed table satisfy the condition. The
+    --- condition may be a predicate function or a value to match.
+    ---
+    ---@param tbl table The indexed table to test.
+    ---@param condition any A predicate function or a value to compare each element against.
+    ---@returns number The number of elements that satisfy the condition.
+    ---@example
+    --- ```lua
+    --- table.count({1, 2, 2, 3}, 2)
+    --- -- 2
+    --- ```
     function self.count(tbl, condition)
       ___.v.indexed(tbl, 1, false)
       ___.v.type(condition, "any", 2, false)
@@ -630,6 +1116,16 @@ local TableClass = Glu.glass.register({
       return #table.n_filter(tbl, condition)
     end
 
+    --- Returns a new indexed table sorted using natural comparison, leaving the
+    --- original table unmodified.
+    ---
+    ---@param tble table The indexed table to sort.
+    ---@returns table A new naturally sorted indexed table.
+    ---@example
+    --- ```lua
+    --- table.natural_sort({"item10", "item2", "item1"})
+    --- -- {"item1", "item2", "item10"}
+    --- ```
     function self.natural_sort(tble)
       ___.v.indexed(tble, 1, false)
 
@@ -641,6 +1137,18 @@ local TableClass = Glu.glass.register({
       return sorted
     end
 
+    --- Sorts an indexed table. If a comparator function is given, the table is
+    --- sorted in place with it; otherwise a new naturally sorted table is
+    --- returned.
+    ---
+    ---@param tbl table The indexed table to sort.
+    ---@param arg function|nil A comparator function. (Optional. When omitted, natural sort is used.)
+    ---@returns table|nil A new naturally sorted table when no comparator is given, otherwise nil.
+    ---@example
+    --- ```lua
+    --- table.sort({3, 1, 2})
+    --- -- {1, 2, 3}
+    --- ```
     function self.sort(tbl, arg)
       ___.v.indexed(tbl, 1, false)
 

--- a/src/scripts/table.lua
+++ b/src/scripts/table.lua
@@ -8,7 +8,7 @@ local TableClass = Glu.glass.register({
     --- collected into a new table.
     ---
     ---@param ... any The value(s) to cast into an indexed table.
-    ---@returns table The resulting indexed table.
+    ---@return table result The resulting indexed table.
     ---@example
     --- ```lua
     --- table.n_cast(1, 2, 3)
@@ -30,7 +30,7 @@ local TableClass = Glu.glass.register({
     ---@param t table The table to map over.
     ---@param fn function The function called as fn(key, value, ...) for each element.
     ---@param ... any Additional arguments passed to the mapping function.
-    ---@returns table A new table with the mapped values.
+    ---@return table result A new table with the mapped values.
     ---@example
     --- ```lua
     --- table.map({1, 2, 3}, function(k, v) return v * 2 end)
@@ -51,7 +51,7 @@ local TableClass = Glu.glass.register({
     --- discarding the keys.
     ---
     ---@param t table The table whose values to collect.
-    ---@returns table An indexed table of the values.
+    ---@return table result An indexed table of the values.
     ---@example
     --- ```lua
     --- table.values({a = 1, b = 2})
@@ -72,7 +72,7 @@ local TableClass = Glu.glass.register({
     ---
     ---@param t table The indexed table to check.
     ---@param typ string|nil The type to check against. (Optional. Default is the type of the first element.)
-    ---@returns boolean True if all elements are of the given type, otherwise false.
+    ---@return boolean is_uniform True if all elements are of the given type, otherwise false.
     ---@example
     --- ```lua
     --- table.n_uniform({1, 2, 3})
@@ -98,7 +98,7 @@ local TableClass = Glu.glass.register({
     --- given indexed table, preserving their first-seen order.
     ---
     ---@param t table The indexed table to deduplicate.
-    ---@returns table A new indexed table of distinct values.
+    ---@return table result A new indexed table of distinct values.
     ---@example
     --- ```lua
     --- table.n_distinct({1, 2, 2, 3, 3, 3})
@@ -120,7 +120,7 @@ local TableClass = Glu.glass.register({
     --- Removes and returns the last element of an indexed table.
     ---
     ---@param t table The indexed table to pop from.
-    ---@returns any The removed last element.
+    ---@return any removed The removed last element.
     ---@example
     --- ```lua
     --- table.pop({1, 2, 3})
@@ -136,7 +136,7 @@ local TableClass = Glu.glass.register({
     ---
     ---@param t table The indexed table to push onto.
     ---@param v any The value to append.
-    ---@returns number The new length of the table.
+    ---@return number length The new length of the table.
     ---@example
     --- ```lua
     --- table.push({1, 2}, 3)
@@ -156,7 +156,7 @@ local TableClass = Glu.glass.register({
     ---
     ---@param t table The indexed table to unshift onto.
     ---@param v any The value to insert at the front.
-    ---@returns number The new length of the table.
+    ---@return number length The new length of the table.
     ---@example
     --- ```lua
     --- table.unshift({2, 3}, 1)
@@ -175,7 +175,7 @@ local TableClass = Glu.glass.register({
     --- remaining elements down.
     ---
     ---@param t table The indexed table to shift from.
-    ---@returns any The removed first element.
+    ---@return any removed The removed first element.
     ---@example
     --- ```lua
     --- table.shift({1, 2, 3})
@@ -193,7 +193,7 @@ local TableClass = Glu.glass.register({
     ---
     ---@param source table An indexed, non-empty table whose values become the keys.
     ---@param spec any A parallel indexed table, a function called as spec(index, key), or a constant value.
-    ---@returns table The resulting associative table.
+    ---@return table result The resulting associative table.
     ---@example
     --- ```lua
     --- table.allocate({"a", "b"}, {1, 2})
@@ -234,7 +234,7 @@ local TableClass = Glu.glass.register({
     --- integers starting at 1.
     ---
     ---@param t table The table to check.
-    ---@returns boolean True if the table is indexed, otherwise false.
+    ---@return boolean is_indexed True if the table is indexed, otherwise false.
     ---@example
     --- ```lua
     --- table.indexed({1, 2, 3})
@@ -257,7 +257,7 @@ local TableClass = Glu.glass.register({
     --- key that is not a positive integer.
     ---
     ---@param t table The table to check.
-    ---@returns boolean True if the table is associative, otherwise false.
+    ---@return boolean is_associative True if the table is associative, otherwise false.
     ---@example
     --- ```lua
     --- table.associative({a = 1})
@@ -280,7 +280,7 @@ local TableClass = Glu.glass.register({
     ---@param t table The indexed table to reduce.
     ---@param fn function The reducer called as fn(accumulator, value, key).
     ---@param initial any The initial value of the accumulator.
-    ---@returns any The final accumulated value.
+    ---@return any acc The final accumulated value.
     ---@example
     --- ```lua
     --- table.reduce({1, 2, 3}, function(acc, v) return acc + v end, 0)
@@ -304,7 +304,7 @@ local TableClass = Glu.glass.register({
     ---@param t table The indexed table to slice.
     ---@param start number The starting index (1-based).
     ---@param stop number|nil The ending index. (Optional. Default is the length of the table.)
-    ---@returns table A new indexed table with the sliced elements.
+    ---@return table result A new indexed table with the sliced elements.
     ---@example
     --- ```lua
     --- table.slice({1, 2, 3, 4}, 2, 3)
@@ -335,8 +335,8 @@ local TableClass = Glu.glass.register({
     ---@param t table The indexed table to remove from.
     ---@param start number The starting index (1-based) of the range to remove.
     ---@param stop number|nil The ending index of the range. (Optional. Default is start.)
-    ---@returns table The modified table with the range removed.
-    ---@returns table An indexed table of the removed elements.
+    ---@return table t The modified table with the range removed.
+    ---@return table snipped An indexed table of the removed elements.
     ---@example
     --- ```lua
     --- table.remove({1, 2, 3, 4}, 2, 3)
@@ -364,7 +364,7 @@ local TableClass = Glu.glass.register({
     ---
     ---@param t table The indexed table to chunk.
     ---@param size number The maximum size of each chunk.
-    ---@returns table A table of chunk tables.
+    ---@return table result A table of chunk tables.
     ---@example
     --- ```lua
     --- table.chunk({1, 2, 3, 4, 5}, 2)
@@ -386,7 +386,7 @@ local TableClass = Glu.glass.register({
     ---
     ---@param tbl table The indexed table to append to.
     ---@param ... any The values or tables to append.
-    ---@returns table The modified table.
+    ---@return table tbl The modified table.
     ---@example
     --- ```lua
     --- table.concat({1, 2}, {3, 4}, 5)
@@ -414,7 +414,7 @@ local TableClass = Glu.glass.register({
     ---
     ---@param tbl table The indexed table to drop from.
     ---@param n number The number of elements to drop from the start.
-    ---@returns table A new indexed table without the first n elements.
+    ---@return table result A new indexed table without the first n elements.
     ---@example
     --- ```lua
     --- table.drop({1, 2, 3, 4}, 2)
@@ -431,7 +431,7 @@ local TableClass = Glu.glass.register({
     ---
     ---@param tbl table The indexed table to drop from.
     ---@param n number The number of elements to drop from the end.
-    ---@returns table A new indexed table without the last n elements.
+    ---@return table result A new indexed table without the last n elements.
     ---@example
     --- ```lua
     --- table.drop_right({1, 2, 3, 4}, 2)
@@ -450,7 +450,7 @@ local TableClass = Glu.glass.register({
     ---@param value any The value to fill with.
     ---@param start number|nil The starting index of the range. (Optional. Default is 1.)
     ---@param stop number|nil The ending index of the range. (Optional. Default is the length of the table.)
-    ---@returns table The modified table.
+    ---@return table tbl The modified table.
     ---@example
     --- ```lua
     --- table.fill({1, 2, 3, 4}, 0, 2, 3)
@@ -475,7 +475,7 @@ local TableClass = Glu.glass.register({
     ---
     ---@param tbl table The indexed table to search.
     ---@param fn function The predicate called as fn(index, value).
-    ---@returns number|nil The index of the first matching element, or nil.
+    ---@return number|nil index The index of the first matching element, or nil.
     ---@example
     --- ```lua
     --- table.find({1, 2, 3}, function(i, v) return v == 2 end)
@@ -498,7 +498,7 @@ local TableClass = Glu.glass.register({
     ---
     ---@param tbl table The indexed table to search.
     ---@param fn function The predicate called as fn(index, value).
-    ---@returns number|nil The index of the last matching element, or nil.
+    ---@return number|nil index The index of the last matching element, or nil.
     ---@example
     --- ```lua
     --- table.find_last({1, 2, 2, 3}, function(i, v) return v == 2 end)
@@ -520,7 +520,7 @@ local TableClass = Glu.glass.register({
     --- the result.
     ---
     ---@param tbl table The indexed table to flatten.
-    ---@returns table A new indexed table flattened one level.
+    ---@return table result A new indexed table flattened one level.
     ---@example
     --- ```lua
     --- table.flatten({1, {2, 3}, 4})
@@ -545,7 +545,7 @@ local TableClass = Glu.glass.register({
     --- depth into the result.
     ---
     ---@param tbl table The indexed table to flatten.
-    ---@returns table A new fully flattened indexed table.
+    ---@return table result A new fully flattened indexed table.
     ---@example
     --- ```lua
     --- table.flatten_deeply({1, {2, {3, 4}}})
@@ -569,7 +569,7 @@ local TableClass = Glu.glass.register({
     --- Returns a new indexed table containing all but the last element.
     ---
     ---@param tbl table The indexed table to take the initial elements from.
-    ---@returns table A new indexed table without the last element.
+    ---@return table result A new indexed table without the last element.
     ---@example
     --- ```lua
     --- table.initial({1, 2, 3})
@@ -586,7 +586,7 @@ local TableClass = Glu.glass.register({
     ---
     ---@param tbl table The indexed table to pull values from.
     ---@param ... any The values to remove.
-    ---@returns table The modified table.
+    ---@return table tbl The modified table.
     ---@example
     --- ```lua
     --- table.pull({1, 2, 3, 2, 1}, 2)
@@ -615,7 +615,7 @@ local TableClass = Glu.glass.register({
     --- Reverses the order of the elements of an indexed table in place.
     ---
     ---@param tbl table The indexed table to reverse.
-    ---@returns table The reversed table.
+    ---@return table tbl The reversed table.
     ---@example
     --- ```lua
     --- table.reverse({1, 2, 3})
@@ -635,7 +635,7 @@ local TableClass = Glu.glass.register({
     --- first occurrence of each value.
     ---
     ---@param tbl table The indexed table to deduplicate.
-    ---@returns table The modified table with duplicates removed.
+    ---@return table tbl The modified table with duplicates removed.
     ---@example
     --- ```lua
     --- table.uniq({1, 2, 2, 3, 1})
@@ -668,7 +668,7 @@ local TableClass = Glu.glass.register({
     --- position into new sub-tables.
     ---
     ---@param tbl table An indexed table of equal-length indexed sub-tables.
-    ---@returns table A new table of sub-tables grouped by position.
+    ---@return table result A new table of sub-tables grouped by position.
     ---@example
     --- ```lua
     --- table.unzip({{1, "a"}, {2, "b"}})
@@ -702,7 +702,7 @@ local TableClass = Glu.glass.register({
     --- Creates a new table with weak references, controlled by the given mode.
     ---
     ---@param opt string|nil The weak mode: "k", "v", or "kv". (Optional. Default is "v".)
-    ---@returns table A new table with the specified weak mode.
+    ---@return table tbl A new table with the specified weak mode.
     ---@example
     --- ```lua
     --- table.new_weak("kv")
@@ -718,7 +718,7 @@ local TableClass = Glu.glass.register({
     --- Determines whether a table holds weak references.
     ---
     ---@param tbl table The table to check.
-    ---@returns boolean True if the table has a weak mode set, otherwise false.
+    ---@return boolean is_weak True if the table has a weak mode set, otherwise false.
     ---@example
     --- ```lua
     --- table.weak(table.new_weak("v"))
@@ -734,7 +734,7 @@ local TableClass = Glu.glass.register({
     --- the same position into new sub-tables.
     ---
     ---@param ... table The equal-length indexed tables to zip.
-    ---@returns table A new table of position-grouped sub-tables.
+    ---@return table results A new table of position-grouped sub-tables.
     ---@example
     --- ```lua
     --- table.zip({1, 2}, {"a", "b"})
@@ -760,7 +760,7 @@ local TableClass = Glu.glass.register({
     ---
     ---@param tbl table The indexed table to search.
     ---@param value any The value to look for.
-    ---@returns boolean True if the value is present, otherwise false.
+    ---@return boolean present True if the value is present, otherwise false.
     ---@example
     --- ```lua
     --- table.includes({1, 2, 3}, 2)
@@ -832,7 +832,7 @@ local TableClass = Glu.glass.register({
     ---
     ---@param tbl table The object table to inspect.
     ---@param extending boolean|nil Whether to include inherited functions. (Optional. Default is false.)
-    ---@returns table An indexed table of function names.
+    ---@return table result An indexed table of function names.
     ---@example
     --- ```lua
     --- table.functions(myObject)
@@ -855,7 +855,7 @@ local TableClass = Glu.glass.register({
     ---
     ---@param tbl table The object table to inspect.
     ---@param extending boolean|nil Whether to include inherited properties. (Optional. Default is false.)
-    ---@returns table An indexed table of property names.
+    ---@return table result An indexed table of property names.
     ---@example
     --- ```lua
     --- table.properties(myObject)
@@ -875,7 +875,7 @@ local TableClass = Glu.glass.register({
     --- set to true.
     ---
     ---@param tbl table The table to check.
-    ---@returns boolean True if the table is an object, otherwise false.
+    ---@return boolean is_object True if the table is an object, otherwise false.
     ---@example
     --- ```lua
     --- table.object({object = true})
@@ -891,7 +891,7 @@ local TableClass = Glu.glass.register({
     ---
     ---@param tbl table The associative table to merge into.
     ---@param value table The associative table whose pairs are copied in.
-    ---@returns table The modified table.
+    ---@return table tbl The modified table.
     ---@example
     --- ```lua
     --- table.add({a = 1}, {b = 2})
@@ -914,7 +914,7 @@ local TableClass = Glu.glass.register({
     ---@param tbl1 table The indexed table to insert into.
     ---@param tbl2 table The indexed table whose elements are inserted.
     ---@param index number|nil The position at which to insert. (Optional. Default is the end of tbl1.)
-    ---@returns table The modified table.
+    ---@return table tbl1 The modified table.
     ---@example
     --- ```lua
     --- table.n_add({1, 4}, {2, 3}, 2)
@@ -940,7 +940,7 @@ local TableClass = Glu.glass.register({
     --- indexed table, yielding each index and value.
     ---
     ---@param tbl table The indexed table to walk.
-    ---@returns function An iterator returning index and value on each call.
+    ---@return function iterator An iterator returning index and value on each call.
     ---@example
     --- ```lua
     --- for i, v in table.walk({"a", "b"}) do print(i, v) end
@@ -960,7 +960,7 @@ local TableClass = Glu.glass.register({
     --- Returns a uniformly random element from an indexed table.
     ---
     ---@param list table The indexed table to choose from.
-    ---@returns any A randomly chosen element.
+    ---@return any element A randomly chosen element.
     ---@example
     --- ```lua
     --- table.element_of({"a", "b", "c"})
@@ -977,7 +977,7 @@ local TableClass = Glu.glass.register({
     --- value is the relative weight of its key.
     ---
     ---@param list table An associative table mapping keys to numeric weights.
-    ---@returns any A randomly chosen key, weighted by its value.
+    ---@return any key A randomly chosen key, weighted by its value.
     ---@example
     --- ```lua
     --- table.element_of_weighted({common = 90, rare = 10})
@@ -1014,7 +1014,7 @@ local TableClass = Glu.glass.register({
     ---
     ---@param tbl table The indexed table to test.
     ---@param condition any A predicate function or a value to compare each element against.
-    ---@returns boolean True if every element satisfies the condition, otherwise false.
+    ---@return boolean matched True if every element satisfies the condition, otherwise false.
     ---@example
     --- ```lua
     --- table.all({2, 4, 6}, function(v) return v % 2 == 0 end)
@@ -1041,7 +1041,7 @@ local TableClass = Glu.glass.register({
     ---
     ---@param tbl table The indexed table to test.
     ---@param condition any A predicate function or a value to compare each element against.
-    ---@returns boolean True if any element satisfies the condition, otherwise false.
+    ---@return boolean matched True if any element satisfies the condition, otherwise false.
     ---@example
     --- ```lua
     --- table.some({1, 2, 3}, 2)
@@ -1061,7 +1061,7 @@ local TableClass = Glu.glass.register({
     ---
     ---@param tbl table The indexed table to test.
     ---@param condition any A predicate function or a value to compare each element against.
-    ---@returns boolean True if no element satisfies the condition, otherwise false.
+    ---@return boolean matched True if no element satisfies the condition, otherwise false.
     ---@example
     --- ```lua
     --- table.none({1, 3, 5}, function(v) return v % 2 == 0 end)
@@ -1081,7 +1081,7 @@ local TableClass = Glu.glass.register({
     ---
     ---@param tbl table The indexed table to test.
     ---@param condition any A predicate function or a value to compare each element against.
-    ---@returns boolean True if exactly one element satisfies the condition, otherwise false.
+    ---@return boolean matched True if exactly one element satisfies the condition, otherwise false.
     ---@example
     --- ```lua
     --- table.one({1, 2, 3}, 2)
@@ -1101,7 +1101,7 @@ local TableClass = Glu.glass.register({
     ---
     ---@param tbl table The indexed table to test.
     ---@param condition any A predicate function or a value to compare each element against.
-    ---@returns number The number of elements that satisfy the condition.
+    ---@return number count The number of elements that satisfy the condition.
     ---@example
     --- ```lua
     --- table.count({1, 2, 2, 3}, 2)
@@ -1120,7 +1120,7 @@ local TableClass = Glu.glass.register({
     --- original table unmodified.
     ---
     ---@param tble table The indexed table to sort.
-    ---@returns table A new naturally sorted indexed table.
+    ---@return table sorted A new naturally sorted indexed table.
     ---@example
     --- ```lua
     --- table.natural_sort({"item10", "item2", "item1"})
@@ -1143,7 +1143,7 @@ local TableClass = Glu.glass.register({
     ---
     ---@param tbl table The indexed table to sort.
     ---@param arg function|nil A comparator function. (Optional. When omitted, natural sort is used.)
-    ---@returns table|nil A new naturally sorted table when no comparator is given, otherwise nil.
+    ---@return table|nil sorted A new naturally sorted table when no comparator is given, otherwise nil.
     ---@example
     --- ```lua
     --- table.sort({3, 1, 2})

--- a/src/scripts/timer.lua
+++ b/src/scripts/timer.lua
@@ -35,11 +35,11 @@ local TimerClass = Glu.glass.register({
     end
 
     --- Creates nested timers and returns true if successful.
-    --- @param name string - The name of the multi timer.
-    --- @param def table - The definition of the multi timer.
-    --- @param delay number - The delay between each timer.
-    --- @return boolean - True if the multi timer was created, errors out if not.
-    --- @example
+    ---@param name string The name of the multi timer.
+    ---@param def table The definition of the multi timer.
+    ---@param delay number The delay between each timer.
+    ---@returns boolean True if the multi timer was created, errors out if not.
+    ---@example
     --- ```lua
     --- -- At intervals of 5 seconds, print "hi", "there", "you", "amazing", and
     --- -- "developer"
@@ -92,9 +92,9 @@ local TimerClass = Glu.glass.register({
     end
 
     --- Kills a multi timer by name.
-    --- @param name string - The name of the multi timer.
-    --- @return boolean|nil - True if the multi timer was killed, nil if it doesn't exist.
-    --- @example
+    ---@param name string The name of the multi timer.
+    ---@returns boolean|nil True if the multi timer was killed, nil if it doesn't exist.
+    ---@example
     --- ```lua
     --- timer.kill_multi("Greetings")
     --- ```

--- a/src/scripts/timer.lua
+++ b/src/scripts/timer.lua
@@ -38,7 +38,7 @@ local TimerClass = Glu.glass.register({
     ---@param name string The name of the multi timer.
     ---@param def table The definition of the multi timer.
     ---@param delay number The delay between each timer.
-    ---@returns boolean True if the multi timer was created, errors out if not.
+    ---@return boolean ok True if the multi timer was created, errors out if not.
     ---@example
     --- ```lua
     --- -- At intervals of 5 seconds, print "hi", "there", "you", "amazing", and
@@ -93,7 +93,7 @@ local TimerClass = Glu.glass.register({
 
     --- Kills a multi timer by name.
     ---@param name string The name of the multi timer.
-    ---@returns boolean|nil True if the multi timer was killed, nil if it doesn't exist.
+    ---@return boolean|nil killed True if the multi timer was killed, nil if it doesn't exist.
     ---@example
     --- ```lua
     --- timer.kill_multi("Greetings")

--- a/src/scripts/try.lua
+++ b/src/scripts/try.lua
@@ -11,6 +11,17 @@ local TryClass = Glu.glass.register({
       result = nil
     }
 
+    --- Starts a new try chain by running the given function under pcall.
+    --- Creates a fresh try object and immediately runs `try` on it, recording
+    --- whether the function succeeded or errored.
+    ---
+    ---@param f function The function to execute.
+    ---@param ... any Arguments passed to the function.
+    ---@returns object The new try object for chaining.
+    ---@example
+    --- ```lua
+    --- try.clone(function() error("boom") end):catch(function(e) end)
+    --- ```
     function self.clone(f, ...)
       local glass = ___.get_glass("try")
       assert(glass, "TryClass not found")
@@ -19,6 +30,17 @@ local TryClass = Glu.glass.register({
     end
 
     -- first, let's try to execute the function
+    --- Runs the given function under pcall and records the result.
+    --- Stores success state, the returned value or error, and updates the try
+    --- object's `result` and `caught` fields.
+    ---
+    ---@param f function The function to execute.
+    ---@param ... any Arguments passed to the function.
+    ---@returns object The try object for chaining.
+    ---@example
+    --- ```lua
+    --- try.try(function() return 42 end):catch(function(e) end)
+    --- ```
     function self.try(f, ...)
       local success, try_result = pcall(f, ...)
       if success then
@@ -45,6 +67,16 @@ local TryClass = Glu.glass.register({
       return self
     end
 
+    --- Runs the given handler with the try result, capturing any error.
+    --- The handler receives the recorded try outcome. Its own success or failure
+    --- is stored in the catch result.
+    ---
+    ---@param f function The handler to run with the try result.
+    ---@returns object The try object for chaining.
+    ---@example
+    --- ```lua
+    --- try.clone(function() error("boom") end):catch(function(e) print(e.error) end)
+    --- ```
     function self.catch(f)
       local success, catch_result = pcall(f, result.try)
       if success then
@@ -65,6 +97,16 @@ local TryClass = Glu.glass.register({
       return self
     end
 
+    --- Always runs the given function, regardless of success or failure.
+    --- The function receives the full result. If the finally block itself errors,
+    --- that error is raised.
+    ---
+    ---@param f function The function to always run.
+    ---@returns object The try object for chaining.
+    ---@example
+    --- ```lua
+    --- try.clone(function() error("boom") end):finally(function(r) end)
+    --- ```
     function self.finally(f)
       -- Pass both success and error information to finally block
       local success, finally_result = pcall(f, result)

--- a/src/scripts/try.lua
+++ b/src/scripts/try.lua
@@ -17,7 +17,7 @@ local TryClass = Glu.glass.register({
     ---
     ---@param f function The function to execute.
     ---@param ... any Arguments passed to the function.
-    ---@returns object The new try object for chaining.
+    ---@return object try The new try object for chaining.
     ---@example
     --- ```lua
     --- try.clone(function() error("boom") end):catch(function(e) end)
@@ -36,7 +36,7 @@ local TryClass = Glu.glass.register({
     ---
     ---@param f function The function to execute.
     ---@param ... any Arguments passed to the function.
-    ---@returns object The try object for chaining.
+    ---@return object self The try object for chaining.
     ---@example
     --- ```lua
     --- try.try(function() return 42 end):catch(function(e) end)
@@ -72,7 +72,7 @@ local TryClass = Glu.glass.register({
     --- is stored in the catch result.
     ---
     ---@param f function The handler to run with the try result.
-    ---@returns object The try object for chaining.
+    ---@return object self The try object for chaining.
     ---@example
     --- ```lua
     --- try.clone(function() error("boom") end):catch(function(e) print(e.error) end)
@@ -102,7 +102,7 @@ local TryClass = Glu.glass.register({
     --- that error is raised.
     ---
     ---@param f function The function to always run.
-    ---@returns object The try object for chaining.
+    ---@return object self The try object for chaining.
     ---@example
     --- ```lua
     --- try.clone(function() error("boom") end):finally(function(r) end)

--- a/src/scripts/url.lua
+++ b/src/scripts/url.lua
@@ -6,9 +6,9 @@ local UrlClass = Glu.glass.register({
     --- Decodes a string that has been URL-encoded. Useful for decoding query
     --- parameters into a more readable format.
     ---
-    --- @param str string - The URL-encoded string to decode.
-    --- @return string - The decoded string.
-    --- @example
+    ---@param str string The URL-encoded string to decode.
+    ---@returns string The decoded string.
+    ---@example
     --- ```lua
     --- url:decode("This%20string%20is%20now%20readable%21%21%21")
     --- -- "This string is now readable!!!"
@@ -26,9 +26,9 @@ local UrlClass = Glu.glass.register({
     --- Encodes a string into a URL-encoded string. Useful for encoding query
     --- parameters into a URL before sending it to a server.
     ---
-    --- @param str string - The string to encode.
-    --- @return string - The URL-encoded string.
-    --- @example
+    ---@param str string The string to encode.
+    ---@returns string The URL-encoded string.
+    ---@example
     --- ```lua
     --- url:encode("This string is now usable in a URL.")
     --- -- "This%20string%20is%20now%20usable%20in%20a%20URL%2E"
@@ -44,9 +44,9 @@ local UrlClass = Glu.glass.register({
 
     --- Parses a query string into a table of key-value pairs.
     ---
-    --- @param query_string string - The query string to parse.
-    --- @return table - A table containing the parsed key-value pairs.
-    --- @example
+    ---@param query_string string The query string to parse.
+    ---@returns table A table containing the parsed key-value pairs.
+    ---@example
     --- ```lua
     --- url:decode_params("name=John&age=30")
     --- -- { name = "John", age = "30" }
@@ -64,9 +64,9 @@ local UrlClass = Glu.glass.register({
 
     --- Encodes a table of key-value pairs into a query string.
     ---
-    --- @param params table - The table of key-value pairs to encode.
-    --- @return string - The encoded query string.
-    --- @example
+    ---@param params table The table of key-value pairs to encode.
+    ---@returns string The encoded query string.
+    ---@example
     --- ```lua
     --- url:encode_params({ name = "John", age = "30" })
     --- -- "name=John&age=30"
@@ -81,9 +81,9 @@ local UrlClass = Glu.glass.register({
 
     --- Parses a URL into its components.
     ---
-    --- @param url string - The URL to parse.
-    --- @return table - A table containing the parsed URL components.
-    --- @example
+    ---@param url string The URL to parse.
+    ---@returns table A table containing the parsed URL components.
+    ---@example
     --- ```lua
     --- url:parse("https://example.com/path/dosomething?name=John&age=30")
     --- -- {

--- a/src/scripts/url.lua
+++ b/src/scripts/url.lua
@@ -7,7 +7,7 @@ local UrlClass = Glu.glass.register({
     --- parameters into a more readable format.
     ---
     ---@param str string The URL-encoded string to decode.
-    ---@returns string The decoded string.
+    ---@return string str The decoded string.
     ---@example
     --- ```lua
     --- url:decode("This%20string%20is%20now%20readable%21%21%21")
@@ -27,7 +27,7 @@ local UrlClass = Glu.glass.register({
     --- parameters into a URL before sending it to a server.
     ---
     ---@param str string The string to encode.
-    ---@returns string The URL-encoded string.
+    ---@return string str The URL-encoded string.
     ---@example
     --- ```lua
     --- url:encode("This string is now usable in a URL.")
@@ -45,7 +45,7 @@ local UrlClass = Glu.glass.register({
     --- Parses a query string into a table of key-value pairs.
     ---
     ---@param query_string string The query string to parse.
-    ---@returns table A table containing the parsed key-value pairs.
+    ---@return table params A table containing the parsed key-value pairs.
     ---@example
     --- ```lua
     --- url:decode_params("name=John&age=30")
@@ -65,7 +65,7 @@ local UrlClass = Glu.glass.register({
     --- Encodes a table of key-value pairs into a query string.
     ---
     ---@param params table The table of key-value pairs to encode.
-    ---@returns string The encoded query string.
+    ---@return string encoded The encoded query string.
     ---@example
     --- ```lua
     --- url:encode_params({ name = "John", age = "30" })
@@ -82,7 +82,7 @@ local UrlClass = Glu.glass.register({
     --- Parses a URL into its components.
     ---
     ---@param url string The URL to parse.
-    ---@returns table A table containing the parsed URL components.
+    ---@return table parsed A table containing the parsed URL components.
     ---@example
     --- ```lua
     --- url:parse("https://example.com/path/dosomething?name=John&age=30")

--- a/src/scripts/version.lua
+++ b/src/scripts/version.lua
@@ -22,10 +22,10 @@ local VersionClass = Glu.glass.register({
     --- string, then it can be a string representation of a number or a semver
     --- string.
     ---
-    --- @param version1 string|number - The first version string or number.
-    --- @param version2 string|number - The second version string or number.
-    --- @return number - 1 if version1 is greater than version2, -1 if version1 is less than version2, and 0 if they are the same.
-    --- @example
+    ---@param version1 string|number The first version string or number.
+    ---@param version2 string|number The second version string or number.
+    ---@returns number 1 if version1 is greater than version2, -1 if version1 is less than version2, and 0 if they are the same.
+    ---@example
     --- ```lua
     --- version.compare("1.0.0", "2.0.0")
     --- -- -1

--- a/src/scripts/version.lua
+++ b/src/scripts/version.lua
@@ -24,7 +24,7 @@ local VersionClass = Glu.glass.register({
     ---
     ---@param version1 string|number The first version string or number.
     ---@param version2 string|number The second version string or number.
-    ---@returns number 1 if version1 is greater than version2, -1 if version1 is less than version2, and 0 if they are the same.
+    ---@return number result 1 if version1 is greater than version2, -1 if version1 is less than version2, and 0 if they are the same.
     ---@example
     --- ```lua
     --- version.compare("1.0.0", "2.0.0")


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reformats all LuaDoc annotation markers across 21 source files, switching from `--- @param`/`--- @return` (with leading space) to the attached `---@param`/`---@return` style, and adds a name token to every `---@return` annotation. It also backfills documentation for numerous functions that had no doc blocks at all.

- Annotation format (`--- @x` → `---@x`) and named return values (`---@return type name`) are correct LuaCATS style throughout.
- New doc blocks for previously undocumented functions cover `fd.lua`, `table.lua`, `string.lua`, `func.lua`, `glass_loader.lua`, `glu.lua`, `http.lua`, `queue.lua`, `queue_stack.lua`, `try.lua`, and others.
- Three files (`try.lua`, `http_request.lua`, `dependency_queue.lua`) use `---@return object` but no `---@class object` definition exists in the codebase, so LuaLS will not resolve this type for hover/completion.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are documentation-only; no executable logic was modified.

Every change in this PR touches only annotation comments. The one real gap is that three files annotate their return type as `object`, a type that has no `---@class` definition in the codebase, so those annotations won't surface useful type information in LuaLS. This doesn't affect runtime behaviour and is easy to follow up on separately.

src/scripts/try.lua, src/scripts/http_request.lua, and src/scripts/dependency_queue.lua each use `---@return object` with no matching class definition.

<sub>Reviews (3): Last reviewed commit: ["Name every @return value (LuaCATS @retur..."](https://github.com/gesslar/glu/commit/13ffea7c7605fe1258be534e8c7e867ce4046752) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38878640)</sub>

<!-- /greptile_comment -->