### PR TITLE
adding bedoc

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -26,10 +26,16 @@ jobs:
       - run: npm ci
       - name: Build single + minified
         run: npm run build
+      - name: Package docs + library
+        run: |
+          tar -czf bedoc.docs.tar.gz -C build docs
+          tar -czf bedoc.library.tar.gz -C build library
       - name: Attach to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           version=$(jq -r '.version' mfile)
           gh release upload --clobber \
-            "$version" build/Glu-min.lua build/Glu-single.lua
+            "$version" \
+            build/Glu-min.lua build/Glu-single.lua \
+            bedoc.docs.tar.gz bedoc.library.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .output
 build/
-docs/
 node_modules/
 /tmp/busted-tests-failed
 test/mudlet/

--- a/bedoc/actions/bedoc-lua-library-formatter.js
+++ b/bedoc/actions/bedoc-lua-library-formatter.js
@@ -1,0 +1,169 @@
+/**
+ * @file Lua library formatter - emits LuaLS "meta" stub files.
+ *
+ * This formatter takes the same parsed documentation data as the markdown
+ * formatter and emits a Lua type-definition stub: every function becomes an
+ * empty `function module.method(...) end` body wrapped in `if false then ...
+ * end` so the file declares types for the Lua language server without ever
+ * executing. These are meant to be dropped into a LuaLS workspace so Mudlet
+ * projects consuming Glu get autocomplete and type information.
+ *
+ * The module/class identity (and an optional @file description) ride along on
+ * the parsed functions as a `file` object, surfaced by the parser.
+ *
+ * @author gesslar
+ * @version 1.0.0
+ * @since 1.0.0
+ */
+
+import {ActionBuilder, ACTIVITY} from "@gesslar/actioneer"
+import {Promised} from "@gesslar/toolkit"
+
+const INDENT = "  "
+const RULE = "-".repeat(78)
+
+/**
+ * Lua library formatter Class - formats parsed documentation into a LuaLS
+ * meta stub file.
+ *
+ * @class
+ */
+export default class LuaLibraryFormatter {
+  /**
+   * Formatter metadata defining its characteristics and contract.
+   *
+   * @readonly
+   * @type {object}
+   * @property {string} kind - The type of action.
+   * @property {string} format - The format of the file this formatter emits.
+   * @property {string} extension - The output file extension.
+   * @property {string} terms - The contract terms file name.
+   */
+  static meta = Object.freeze({
+    kind: "formatter",
+    format: "lua-library",
+    extension: "lua",
+    terms: "ref://./bedoc-lua-library-formatter.yaml"
+  })
+
+  /**
+   * Configures the formatter using ActionBuilder's fluent API.
+   *
+   * @param {ActionBuilder} builder - The ActionBuilder instance to configure
+   * @returns {ActionBuilder} The configured builder instance
+   */
+  setup = builder => builder
+    .do("Format stubs", ACTIVITY.SPLIT,
+      ctx => ctx, // splitter
+      this.#rejoin, // rejoiner
+      new ActionBuilder()
+        .do("Format stub", this.#formatStub)
+    )
+    .do("Finalize", this.#finalize)
+
+  /**
+   * Formats a single function into an annotated, non-executing stub.
+   *
+   * @param {object} ctx - A parsed function object
+   * @returns {object} The context with a `stub` string attached
+   * @private
+   */
+  #formatStub = ctx => {
+    const lines = []
+    const module = ctx.file?.module || "_"
+    const method = ctx.signature?.method || ctx.name
+
+    // Description block (kept in the new `--- ` style).
+    const description = (ctx.description ?? [])
+      .map(line => line.trim())
+      .join("\n")
+      .trim()
+
+    if(description)
+      for(const line of description.split("\n"))
+        lines.push(`${INDENT}--- ${line}`.trimEnd())
+
+    const hasTags = ctx.param?.length || ctx.return?.length
+
+    if(description && hasTags)
+      lines.push(`${INDENT}---`)
+
+    // @param tags — name, type, then freeform description.
+    for(const p of ctx.param ?? []) {
+      const type = Array.isArray(p.type) ? p.type.join("|") : p.type
+      const detail = (p.content ?? []).map(c => c.trim()).filter(Boolean).join(" ")
+
+      lines.push(`${INDENT}---@param ${p.name} ${type}${detail ? ` ${detail}` : ""}`)
+    }
+
+    // @return tags — one per returned value. LuaCATS uses the singular
+    // `@return` (LuaLS ignores `@returns`). With a name it reads
+    // `<type> <name> <desc>`; without one, `# ` delimits the description so
+    // LuaLS doesn't mistake its first word for the return name.
+    for(const r of ctx.return ?? []) {
+      const type = Array.isArray(r.type) ? r.type.join("|") : r.type
+      const detail = (r.content ?? []).map(c => c.trim()).filter(Boolean).join(" ")
+
+      let line = `${INDENT}---@return ${type}`
+
+      if(r.name)
+        line += ` ${r.name}${detail ? ` ${detail}` : ""}`
+      else if(detail)
+        line += ` # ${detail}`
+
+      lines.push(line)
+    }
+
+    const parameters = ctx.signature?.parameters?.join(", ") ?? ""
+    lines.push(`${INDENT}function ${module}.${method}(${parameters}) end`)
+
+    return Object.assign({}, ctx, {stub: lines.join("\n")})
+  }
+
+  #rejoin(_, settled) {
+    if(Promised.hasRejected(settled))
+      Promised.throw(settled)
+
+    return Promised.values(settled)
+  }
+
+  /**
+   * Wraps the formatted stubs in the LuaLS meta header/footer.
+   *
+   * @param {Array<object>} ctx - Array of formatted function objects
+   * @returns {string} The complete Lua stub file
+   * @private
+   */
+  #finalize = ctx => {
+    const functions = ctx.flat()
+
+    if(!functions.length)
+      return ""
+
+    const {module, class: className, description} = functions[0].file ?? {}
+    const name = className || "Unknown"
+
+    const header = [
+      `---@meta ${name}`,
+      "",
+      RULE,
+      `-- ${name}`,
+      RULE,
+      "",
+    ]
+
+    if(description) {
+      for(const line of description.split("\n"))
+        header.push(`--- ${line}`.trimEnd())
+    }
+
+    header.push(`---@class ${name}`)
+    header.push(`${module || "_"} = {}`)
+    header.push("")
+    header.push("if false then -- ensure that functions do not get defined")
+
+    const body = functions.map(f => f.stub).join("\n\n")
+
+    return `${header.join("\n")}\n${body}\nend\n`
+  }
+}

--- a/bedoc/actions/bedoc-lua-library-formatter.yaml
+++ b/bedoc/actions/bedoc-lua-library-formatter.yaml
@@ -1,0 +1,87 @@
+# yaml-language-server: $schema=https://schema.gesslar.dev/bedoc/v1/bedoc-action.json
+
+$schema: https://schema.gesslar.dev/bedoc/v1/bedoc-action.json
+accepts:
+  type: object
+  required:
+    - functions
+  properties:
+    functions:
+      type: array
+      items:
+        type: object
+        required:
+          - name
+          - signature
+        properties:
+          name:
+            type: string
+          file:
+            type: object
+            properties:
+              module:
+                type: string
+              class:
+                type: string
+              description:
+                type: string
+          signature:
+            type: object
+            required:
+              - name
+            properties:
+              name:
+                type: string
+              method:
+                type: string
+              type:
+                type: string
+              parameters:
+                type: array
+                items:
+                  type: string
+          description:
+            type: array
+            items:
+              type: string
+          param:
+            type: array
+            items:
+              type: object
+              required:
+                - type
+                - name
+              properties:
+                type:
+                  oneOf:
+                    - type: string
+                    - type: array
+                      items:
+                        type: string
+                name:
+                  type: string
+                content:
+                  type: array
+                  items:
+                    type: string
+          return:
+            type: array
+            items:
+              type: object
+              required:
+                - type
+              properties:
+                type:
+                  oneOf:
+                    - type: string
+                    - type: array
+                      items:
+                        type: string
+                content:
+                  type: array
+                  items:
+                    type: string
+          example:
+            type: array
+            items:
+              type: string

--- a/bedoc/actions/bedoc-lua-parser.js
+++ b/bedoc/actions/bedoc-lua-parser.js
@@ -1,0 +1,341 @@
+/**
+ * @file Lua Parser - A parser for extracting documentation from Lua files.
+ *
+ * This parser specifically handles Lua function documentation comments and
+ * extracts structured information including descriptions, parameters, return
+ * types, and examples.
+ *
+ * The parser uses a contract-based approach defined in bedoc-lua-parser.yaml
+ * and integrates with the BeDoc documentation system through ActionBuilder.
+ *
+ * @author gesslar
+ * @version 1.0.0
+ * @since 1.0.0
+ */
+
+import {ActionBuilder, ACTIVITY} from "@gesslar/actioneer"
+import {Collection} from "@gesslar/toolkit"
+
+/**
+ * Lua Parser Class - Parses Lua files to extract function documentation.
+ *
+ * This parser is designed to work with Lua source files, extracting LDoc
+ * comments and function signatures. It identifies functions with their scope,
+ * delimiter, method name, parameters, and associated documentation.
+ *
+ * @class
+ */
+export default class LuaParser {
+  /**
+   * Parser metadata defining its characteristics and contract.
+   *
+   * @readonly
+   * @type {object}
+   * @property {string} kind - The type of action.
+   * @property {string} input - The input file type this parser handles.
+   * @property {string} terms - The contract file name.
+   */
+  static meta = Object.freeze({
+    kind: "parser",
+    input: "lua",
+    terms: "ref://./bedoc-lua-parser.yaml"
+  })
+
+  /**
+   * Configures the parser using ActionBuilder's fluent API.
+   *
+   * This method sets up the parsing structure and extraction methods for Lua
+   * documentation.
+   *
+   * It defines:
+   * - Comment block structure (LDoc-style --- comments)
+   * - Function signature patterns with Lua-specific scope/method syntax
+   * - Extraction methods for descriptions, tags, and return values
+   *
+   * @param {ActionBuilder} builder - The ActionBuilder instance to configure
+   * @returns {ActionBuilder} The configured builder instance
+   * @example
+   * // Lua function patterns matched:
+   * // function MyModule.my_function(arg1, arg2)
+   * // function MyModule:my_method(arg1, arg2)
+   * @see ActionBuilder
+   */
+  setup = builder => builder
+    .do("Extract blocks", this.#extractBlocks)
+    .do("Process functions", ACTIVITY.SPLIT,
+      ctx => ctx, // splitter
+      ctx => ctx, // rejoiner
+      new ActionBuilder()
+        .do("Extract signature", this.#extractSignature)
+        .do("Extract description", this.#extractDescription)
+        .do("Extract tags", this.#extractTags)
+    )
+    .done(this.#finally)
+
+  #extractBlocks = ctx => {
+    // Capture the module/class identity from the Glu.glass.register({...}) head.
+    // The library formatter needs these for the ---@class / `module = {}` lines;
+    // the markdown formatter simply ignores them.
+    this.#meta = {
+      module: ctx.match(/\bname\s*=\s*["']([^"']+)["']/)?.[1] ?? "",
+      class: ctx.match(/\bclass_name\s*=\s*["']([^"']+)["']/)?.[1] ?? "",
+      description: ctx.match(/---\s?@file\b[ \t]*(?<text>.*)/)?.groups?.text?.trim() ?? "",
+    }
+
+    const result = []
+    const lines = ctx.split(/\r?\n/)
+
+    while(lines.length) {
+      const block = {}
+
+      // Find the start of a comment block
+      const startIndex = lines.findIndex(line =>
+        this.#regexes.get("comment-start").test(line.trim())
+      )
+      if(startIndex < 0)
+        break
+
+      // Remove everything before the comment block
+      lines.splice(0, startIndex)
+
+      // Collect all consecutive comment lines
+      const commentLines = []
+      while(lines.length && this.#regexes.get("comment-start").test(lines[0].trim())) {
+        commentLines.push(lines.shift())
+      }
+
+      block.lines = commentLines
+
+      // Look ahead for a function definition, stopping at the next comment start
+      const funcIndex = lines.findIndex(line => {
+        const trimmed = line.trim()
+
+        return this.#regexes.get("function").test(trimmed) ||
+               this.#regexes.get("comment-start").test(trimmed)
+      })
+
+      if(funcIndex >= 0 && this.#regexes.get("function").test(lines[funcIndex].trim())) {
+        block.function = this.#regexes.get("function").exec(lines[funcIndex].trim())
+        lines.splice(0, funcIndex + 1)
+        result.push(block)
+      } else if(funcIndex >= 0) {
+        // Hit another comment start before a function — discard this block
+        lines.splice(0, funcIndex)
+      }
+      // else: no more lines, block has no function — discard
+    }
+
+    return result
+  }
+
+  #extractSignature = ctx => {
+    const {function: func} = ctx
+    if(!func?.groups?.name)
+      return ctx
+
+    const groups = func.groups
+    const signature = {
+      name: groups.name,
+      scope: groups.scope ?? null,
+      delimiter: groups.delimiter ?? null,
+      method: groups.method,
+      modifiers: [],
+      access: "",
+      parameters: groups.parms?.split(",").map(p => p.trim()) ?? []
+    }
+
+    return Object.assign(ctx, {signature})
+  }
+
+  /**
+   * Extracts the description section from LDoc-style comment lines.
+   *
+   * Processes comment lines to extract the main description text that appears
+   * before any @tag declarations.
+   *
+   * @param {object} ctx - The block context being processed
+   * @returns {object} The context with description added
+   * @private
+   */
+  #extractDescription = ctx => {
+    const {lines} = ctx
+
+    const comment = this.#regexes.get("comment-content")
+    const tagId = this.#regexes.get("tag-id")
+
+    const description = []
+    Object.assign(ctx, {description})
+
+    while(lines.length > 0) {
+      const line = lines[0].trim()
+
+      if(!comment.test(line))
+        break
+
+      if(tagId.test(line))
+        break
+
+      lines.shift()
+      const {content} = comment.exec(line)?.groups ?? {}
+      description.push(content ?? "")
+    }
+
+    return ctx
+  }
+
+  /**
+   * Extracts LDoc-style tags from comment lines.
+   *
+   * Handles @param, @return/@returns, @example, and @name tags.
+   *
+   * @param {object} ctx - The block context being processed
+   * @returns {object} The context with tags added
+   * @private
+   */
+  #extractTags = ctx => {
+    const {lines} = ctx
+
+    const comment = this.#regexes.get("comment-content")
+    const tagPattern = this.#regexes.get("tag")
+    const paramContent = this.#regexes.get("param-content")
+    const returnContent = this.#regexes.get("return-content")
+    const tagId = this.#regexes.get("tag-id")
+
+    const extractedTags = {}
+    Object.assign(ctx, {tag: extractedTags})
+
+    while(lines.length > 0) {
+      const line = lines.shift()
+      const lineTrimmed = line.trim()
+
+      if(!comment.test(lineTrimmed))
+        continue
+
+      const tagMatch = tagPattern.exec(lineTrimmed)
+      if(!tagMatch)
+        continue
+
+      const {tag, content} = tagMatch.groups
+      const normalizedTag = tag === "returns" ? "return" : tag
+
+      if(normalizedTag === "return") {
+        const retMatch = returnContent.exec(content)
+        if(retMatch) {
+          const {type, rest} = retMatch.groups
+          const entry = {type, content: []}
+          const remainder = rest ?? ""
+          const hashMatch = remainder.match(/^#\s*(?<desc>.*)$/)
+
+          if(hashMatch) {
+            // ---@return <type> # <description>  (explicitly no name)
+            entry.content = hashMatch.groups.desc ? [hashMatch.groups.desc] : []
+          } else if(remainder) {
+            // ---@return <type> <name> <description>
+            const named = remainder.match(/^(?<name>\S+)(?:\s+(?<desc>.*))?$/)
+            entry.name = named.groups.name
+            entry.content = named.groups.desc ? [named.groups.desc] : []
+          }
+
+          if(!extractedTags["return"])
+            extractedTags["return"] = []
+
+          extractedTags["return"].push(entry)
+        }
+      } else if(normalizedTag === "name") {
+        if(content)
+          extractedTags["name"] = content
+      } else if(normalizedTag === "example") {
+        const exampleLines = content ? [content] : []
+
+        while(lines.length > 0) {
+          const next = lines[0].trim()
+          if(!comment.test(next) || tagId.test(next))
+            break
+
+          lines.shift()
+          const {content: lineContent} = comment.exec(next)?.groups ?? {}
+          exampleLines.push(lineContent ?? "")
+        }
+
+        extractedTags["example"] = exampleLines
+      } else if(normalizedTag === "param") {
+        const paramMatch = paramContent.exec(content)
+        if(paramMatch) {
+          const {name, type, content: desc} = paramMatch.groups
+          const paramEntry = {type, name, content: desc ? [desc] : []}
+
+          if(!extractedTags["param"])
+            extractedTags["param"] = []
+
+          extractedTags["param"].push(paramEntry)
+
+          while(lines.length > 0) {
+            const next = lines[0].trim()
+            if(!comment.test(next) || tagId.test(next))
+              break
+
+            lines.shift()
+            const {content: lineContent} = comment.exec(next)?.groups ?? {}
+            paramEntry.content.push(lineContent ?? "")
+          }
+        }
+      }
+    }
+
+    return ctx
+  }
+
+  /**
+   * Final processing method called after all extraction is complete.
+   *
+   * @param {Array<object>} ctx - Array of extracted block data
+   * @returns {Promise<object>} The transformation results.
+   * @private
+   */
+  #finally = async ctx => {
+    const functions = await Collection.asyncMap(ctx, async func => {
+      const result = {
+        name: func.function.groups.name,
+        file: this.#meta,
+        description: func.description,
+        signature: {
+          ...func.signature,
+          type: (func.tag?.return ?? []).map(r => r.type).join(", "),
+        },
+      }
+
+      const tags = func.tag ?? {}
+
+      if(tags.param)
+        result.param = tags.param
+          .map(({type, name, content}) => ({type, name, content}))
+
+      if(tags.return)
+        result.return = tags.return
+
+      if(tags.example)
+        result.example = tags.example
+
+      return result
+    })
+
+    return {functions}
+  }
+
+  // Module/class identity captured per-file from the register({...}) head.
+  #meta = null
+
+  // HERE BE DRAGONS! YOU DONE BEEN WARNED, FUGGAH!
+  #regexes = new Map([
+    ["comment-start", /^\s*---\s?.*$/],
+    ["comment-content", /^\s*---\s?(?<content>.*)$/],
+    ["blank", /^\s*$/],
+    ["tag-id", /^\s*---\s?@[a-zA-Z]/],
+    ["tag", /^\s*---\s?@(?<tag>name|param|return|returns|example)\b\s*(?<content>.*)$/],
+    // LuaCATS: ---@param <name> <type> [description]
+    ["param-content", /^(?<name>\S+)\s+(?<type>\S+)(?:\s+(?<content>.*))?$/],
+    // LuaCATS: ---@returns <type> [description]
+    ["return-content", /^(?<type>\S+)(?:\s+(?<rest>.*))?$/],
+    ["function", /^\s*function\s+(?<name>(?<scope>[a-zA-Z_]\w*(?=[.:]))?(?<delimiter>[.:])?(?<method>[a-zA-Z_]\w*))\s*\((?<parms>.+)?\)\s*(?:end)?$/],
+  ])
+}

--- a/bedoc/actions/bedoc-lua-parser.yaml
+++ b/bedoc/actions/bedoc-lua-parser.yaml
@@ -1,0 +1,91 @@
+# yaml-language-server: $schema=https://schema.gesslar.dev/bedoc/v1/bedoc-action.json
+
+$schema: https://schema.gesslar.dev/bedoc/v1/bedoc-action.json
+provides:
+  type: object
+  required:
+    - functions
+  properties:
+    functions:
+      type: array
+      items:
+        type: object
+        required:
+          - name
+          - signature
+        properties:
+          name:
+            type: string
+          file:
+            type: object
+            properties:
+              module:
+                type: string
+              class:
+                type: string
+              description:
+                type: string
+          signature:
+            type: object
+            required:
+              - name
+            properties:
+              name:
+                type: string
+              scope:
+                type: string
+              delimiter:
+                type: string
+              method:
+                type: string
+              modifiers:
+                type: array
+                items:
+                  type: string
+              access:
+                type: string
+              type:
+                type: string
+              parameters:
+                type: array
+                items:
+                  type: string
+          description:
+            type: array
+            items:
+              type: string
+          param:
+            type: array
+            items:
+              type: object
+              required:
+                - type
+                - name
+              properties:
+                type:
+                  type: string
+                name:
+                  type: string
+                content:
+                  type: array
+                  items:
+                    type: string
+          return:
+            type: array
+            items:
+              type: object
+              required:
+                - type
+              properties:
+                type:
+                  type: string
+                name:
+                  type: string
+                content:
+                  type: array
+                  items:
+                    type: string
+          example:
+            type: array
+            items:
+              type: string

--- a/bedoc/actions/bedoc-markdown-formatter.js
+++ b/bedoc/actions/bedoc-markdown-formatter.js
@@ -1,0 +1,271 @@
+/**
+ * @file Markdown formatter - A formatter for converting structured
+ * documentation data into Markdown format.
+ *
+ * This formatter takes parsed documentation objects (functions with descriptions,
+ * parameters, return types, and examples) and formats them as readable
+ * Markdown output.
+ *
+ * The formatter uses a pipeline approach defined via ActionBuilder and
+ * integrates with the BeDoc documentation system.
+ *
+ * @author gesslar
+ * @version 1.0.0
+ * @since 1.0.0
+ */
+
+import {ActionBuilder, ACTIVITY} from "@gesslar/actioneer"
+import {Promised} from "@gesslar/toolkit"
+
+/**
+ * Markdown formatter Class - Formats parsed documentation into Markdown.
+ *
+ * This formatter is designed to work with the structured output from BeDoc
+ * parsers, converting function documentation into well-formatted Markdown
+ * files with headers, parameter lists, return types, and examples.
+ *
+ * @class
+ */
+export default class Markdownformatter {
+  /**
+   * Printer metadata defining its characteristics and contract.
+   *
+   * @readonly
+   * @type {object}
+   * @property {string} kind - The type of action.
+   * @property {string} format - The format of the file this formatter emits.
+   * @property {string} terms - The contract terms file name.
+   */
+  static meta = Object.freeze({
+    kind: "formatter",
+    format: "markdown",
+    extension: "md",
+    terms: "ref://./bedoc-markdown-formatter.yaml"
+  })
+
+  /**
+   * Configures the formatter using ActionBuilder's fluent API.
+   *
+   * This method sets up the formatting pipeline:
+   * - Prepare and sort functions
+   * - Format each function into Markdown sections (via SPLIT)
+   * - Finalize by joining all sections into the output
+   *
+   * @param {ActionBuilder} builder - The ActionBuilder instance to configure
+   * @returns {ActionBuilder} The configured builder instance
+   */
+  setup = builder => builder
+    .do("Format functions", ACTIVITY.SPLIT,
+      ctx => ctx, // splitter. just bare, nothing to do here.
+      this.#rejoinFormatted, // rejoiner
+      new ActionBuilder()
+        .do("Format function", this.#formatFunction)
+    )
+    .do("Finalize", this.#finalize)
+
+  /**
+   * Formats a single function's documentation into Markdown.
+   *
+   * Processes each section of a function (name, description, parameters,
+   * return type, and examples) into formatted Markdown text.
+   *
+   * @param {object} ctx - A parsed function object
+   * @param {string} ctx.name - The function name
+   * @param {Array<string>} [ctx.description] - Description lines
+   * @param {Array<object>} [ctx.param] - Parameter definitions
+   * @param {object} [ctx.return] - Return type info
+   * @param {Array<string>} [ctx.example] - Example lines
+   * @returns {string} Formatted Markdown for this function
+   * @private
+   */
+  #formatFunction = ctx => {
+    // TODO: hook(SECTION_LOAD, func)
+    const sections = []
+
+    // 1. Print the qualified function name (module.method, not self.method)
+    const module = ctx.file?.module
+    const method = ctx.signature?.method || ctx.name?.replace(/^self\./, "")
+    const qualified = module ? `${module}.${method}` : method
+    const parameters = ctx.signature?.parameters?.join(", ") ?? ""
+
+    if(qualified) {
+      sections.push(`## ${qualified}`)
+      sections.push(`\`function ${qualified}(${parameters})\``)
+    }
+
+    // 2. Print the description
+    if(ctx.description?.length) {
+      // TODO: hook(ENTER, {sectionName: "description", ...})
+      const formatted = ctx.description.map(line => line.trim()).join("\n").trim()
+      // TODO: hook(EXIT, {sectionName: "description", ...})
+      sections.push(formatted)
+    }
+
+    // 3. Print the parameters
+    if(ctx.param?.length) {
+      // TODO: hook(ENTER, {sectionName: "param", ...})
+      const params = ctx.param.map(p => {
+        let paramName = p.name
+        let optional = false
+        let defaultValue = null
+
+        // Determine if this is an optional parameter
+        const optionalMatch = paramName.match(/^\[(.*)\]$/)
+        if(optionalMatch) {
+          optional = true
+          paramName = optionalMatch[1]
+        }
+
+        // Determine if there is a default value
+        const defaultMatch = paramName.match(/(.*)=(.*)/)
+        if(defaultMatch) {
+          paramName = defaultMatch[1]
+          defaultValue = defaultMatch[2]
+        }
+
+        const optionalAndOrDefault = optional || defaultValue
+          ? (() => {
+            if(optional && defaultValue)
+              return ` (Optional. Default: ${defaultValue})`
+            else if(optional)
+              return " (Optional)"
+            else if(defaultValue)
+              return ` (Default: ${defaultValue})`
+            else
+              throw new Error("Uhm, we seem to have hit a bump.")
+          })()
+          : ""
+
+        const content = [...(p.content ?? [])]
+        while(content.length && (!content.at(0) || !content.at(-1))) {
+          if(!content.at(0))
+            content.shift()
+
+          if(!content.at(-1))
+            content.pop()
+        }
+
+        return `* **${paramName}** *${p.type}${optionalAndOrDefault}*` +
+          `: ${content.map(c => c.trim()).join(" ")}`
+      })
+      // TODO: hook(EXIT, {sectionName: "param", ...})
+
+      sections.push(params.join("\n"))
+    }
+
+    // 4. Print the return type(s)
+    if(ctx.return?.length) {
+      // TODO: hook(ENTER, {sectionName: "return", ...})
+      const lines = ctx.return.map(ret => {
+        const type = Array.isArray(ret.type) ? ret.type.join("|") : ret.type
+        const name = ret.name ? ` \`${ret.name}\`` : ""
+        const desc = (ret.content ?? []).map(c => c.trim()).filter(Boolean).join(" ")
+
+        return `**${type}**${name}${desc ? ` — ${desc}` : ""}`
+      })
+      // TODO: hook(EXIT, {sectionName: "return", ...})
+
+      sections.push("### Returns\n\n" + lines.join("\n"))
+    }
+
+    // 5. Print the examples
+    if(ctx.example?.length) {
+      // TODO: hook(ENTER, {sectionName: "example", ...})
+      const formatted = "### Example\n\n" + ctx.example.join("\n")
+      // TODO: hook(EXIT, {sectionName: "example", ...})
+
+      sections.push(formatted)
+    }
+
+    return Object.assign({}, {...ctx, formatted: sections})
+  }
+
+  #rejoinFormatted(_, settled) {
+    if(Promised.hasRejected(settled))
+      Promised.throw(settled)
+
+    const values = Promised.values(settled)
+    const formatted = values.map(e => e.formatted)
+
+    formatted.push("") // trailing blank line at the end of the document
+
+    return formatted
+  }
+
+  /**
+   * Final processing method called after all formatting is complete.
+   *
+   * Joins the formatted function sections into a single Markdown document.
+   *
+   * @param {Array<string>} ctx - Array of formatted Markdown strings
+   * @returns {string} The complete Markdown output
+   * @private
+   */
+  #finalize = ctx => {
+    // TODO: hook(END, ctx)
+    return ctx.flat().join("\n\n")
+  }
+}
+
+/**
+ * @todo Reintegrate the following legacy utilities as needed.
+ *
+ * --- Signature formatting ---
+ *
+ * Expects a `signature` object on each function with shape:
+ *   { access, modifiers: string[], type, name, parameters: string[] }
+ *
+ * output = `${w.access} ` +
+ *   `${w.modifiers.length ? w.modifiers.join(" ") + " " : ""}` +
+ *   `*${w.type}* **${w.name}**` +
+ *   `(${w.parameters.join(", ")})`
+ *
+ * --- Word wrap utility ---
+ *
+ * wrap(str, wrapAt = 80, indentAt = 0) {
+ *   const sections = str.split("\n").map(section => {
+ *     let parts = section.split(" ")
+ *     let inCodeBlock = false
+ *     let isStartOfLine = true
+ *
+ *     if(section[0] === " ")
+ *       parts = ["", ...parts]
+ *
+ *     let running = 0
+ *
+ *     parts = parts.map(part => {
+ *       if(isStartOfLine && /^```(?:\w+)?$/.test(part)) {
+ *         inCodeBlock = !inCodeBlock
+ *         running += part.length + 1
+ *         isStartOfLine = false
+ *         return part
+ *       }
+ *
+ *       if(part[0] === "\n") {
+ *         running = 0
+ *         isStartOfLine = true
+ *         return part
+ *       }
+ *
+ *       running += part.length + 1
+ *       isStartOfLine = false
+ *
+ *       if(!inCodeBlock && running >= wrapAt) {
+ *         running = part.length + indentAt
+ *         isStartOfLine = true
+ *         return "\n" + " ".repeat(indentAt) + part
+ *       }
+ *
+ *       return part
+ *     })
+ *
+ *     return parts
+ *       .join(" ")
+ *       .split("\n")
+ *       .map(line => line.trimEnd())
+ *       .join("\n")
+ *   })
+ *
+ *   return sections.join("\n")
+ * }
+ */

--- a/bedoc/actions/bedoc-markdown-formatter.yaml
+++ b/bedoc/actions/bedoc-markdown-formatter.yaml
@@ -1,0 +1,100 @@
+# yaml-language-server: $schema=https://schema.gesslar.dev/bedoc/v1/bedoc-action.json
+
+$schema: https://schema.gesslar.dev/bedoc/v1/bedoc-action.json
+accepts:
+  type: object
+  required:
+    - functions
+  properties:
+    functions:
+      type: array
+      items:
+        type: object
+        required:
+          - name
+          - signature
+        properties:
+          name:
+            type: string
+          signature:
+            type: object
+            required:
+              - name
+            properties:
+              access:
+                type: string
+                enum: [protected, public, private]
+              modifier1:
+                type: string
+                enum: [nomask, varargs]
+              modifier2:
+                type: string
+                enum: [nomask, varargs]
+              type:
+                type: string
+                enum:
+                  [
+                    array,
+                    buffer,
+                    float,
+                    function,
+                    int,
+                    mapping,
+                    mixed,
+                    object,
+                    string,
+                    void,
+                  ]
+              name:
+                type: string
+              parameters:
+                type: array
+                items:
+                  type: string
+          description:
+            type: array
+            items:
+              type: string
+          param:
+            type: array
+            items:
+              type: object
+              required:
+                - type
+                - name
+              properties:
+                type:
+                  oneOf:
+                    - type: string
+                    - type: array
+                      items:
+                        type: string
+                name:
+                  type: string
+                content:
+                  type: array
+                  items:
+                    type: string
+          return:
+            type: array
+            items:
+              type: object
+              required:
+                - type
+              properties:
+                type:
+                  oneOf:
+                    - type: string
+                    - type: array
+                      items:
+                        type: string
+                name:
+                  type: string
+                content:
+                  type: array
+                  items:
+                    type: string
+          example:
+            type: array
+            items:
+              type: string

--- a/bedoc/bedoc.yaml
+++ b/bedoc/bedoc.yaml
@@ -1,0 +1,30 @@
+# Glu docs and library generation.
+#
+# Scrapes the Lua comment blocks out of the source code and emits
+# documentation, among other things.
+#
+# Run from the project root:
+#
+#   npx bedoc --config bedoc/bedoc.yaml --sub docs
+#   npx bedoc --config bedoc/bedoc.yaml --sub library
+#
+
+# Pinned parser (no discovery) — they are not published packages.
+parser: bedoc/actions/bedoc-lua-parser.js
+
+# Every lua source file.
+input: [ src/scripts/*.lua ]
+
+# Don't show all the stages
+terse: true
+
+sub:
+  # For regular documentation.
+  - name: docs
+    formatter: bedoc/actions/bedoc-markdown-formatter.js
+    output: build/docs/
+
+  # For generating a LuaLS meta stub library
+  - name: library
+    formatter: bedoc/actions/bedoc-lua-library-formatter.js
+    output: build/library/

--- a/bedoc/package.json
+++ b/bedoc/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/mfile
+++ b/mfile
@@ -1,7 +1,7 @@
 {
   "package": "Glu",
   "title": "Lua class library for Mudlet",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "gesslar",
   "icon": "liquid-glue.png",
   "dependencies": "",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,50 +1,51 @@
 {
   "name": "glu",
-  "version": "1.20.0",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glu",
-      "version": "1.20.0",
+      "version": "2.0.2",
       "license": "0BSD",
       "devDependencies": {
-        "@gesslar/bedoc": "^1.11.0",
-        "@gesslar/muddy": "^2.2.2"
+        "@gesslar/bedoc": "^2.1.3",
+        "@gesslar/muddy": "^2.2.3",
+        "@gesslar/toolkit": "^5.6.0"
       }
     },
     "node_modules/@gesslar/actioneer": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@gesslar/actioneer/-/actioneer-3.1.0.tgz",
-      "integrity": "sha512-xSM9u09lABt70BtlbYnhR5cuAwQnl1+iH9A7au3HLMwgrPeb8UJjYVo1FlN+CZRKlZkWqfrcxYHAqZrdRyY7JA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@gesslar/actioneer/-/actioneer-3.1.1.tgz",
+      "integrity": "sha512-SCdzcxl3SbCW+GScIkewRIlhL6DY6L7DLdCjMA3Me8ovW9FIv/dbj+YY5BkAdQ4ZTndasHzxZewT69snc/GllQ==",
       "dev": true,
       "license": "0BSD",
       "dependencies": {
-        "@gesslar/toolkit": "^5.5.2"
+        "@gesslar/toolkit": "^5.6.0"
       },
       "engines": {
         "node": ">=24"
       }
     },
     "node_modules/@gesslar/bedoc": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@gesslar/bedoc/-/bedoc-1.11.0.tgz",
-      "integrity": "sha512-R5o4TBj8rGk5+FRqk5aek5KtWKfwa5QZeK93dqehw3Rvz2D5PQH18LEK0rIZN0/b9SSZvQyD7Ja/D+7/H/3ozA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@gesslar/bedoc/-/bedoc-2.1.3.tgz",
+      "integrity": "sha512-bE8Vc3dJBZl50/KLa3TqxCMf5artFp7MXxD9odlnUphlKpnBaSc43XexsBWtYQdGoUF/EMg9PPg217OJnd+fZg==",
       "dev": true,
       "license": "Unlicense",
       "dependencies": {
-        "ajv": "^8.17.1",
-        "commander": "^13.0.0",
-        "dotenv": "^16.4.7",
-        "error-stack-parser": "^2.1.4",
-        "globby": "^14.0.2",
-        "json5": "^2.2.3",
-        "micromatch": "^4.0.8",
-        "node-fetch": "^3.3.2",
-        "yaml": "^2.7.0"
+        "@gesslar/actioneer": "^3.1.1",
+        "@gesslar/colours": "^1.0.0",
+        "@gesslar/negotiator": "^1.0.0",
+        "@gesslar/toolkit": "^5.6.0",
+        "commander": "^15.0.0",
+        "error-stack-parser": "^2.1.4"
       },
       "bin": {
         "bedoc": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@gesslar/colours": {
@@ -61,17 +62,17 @@
       }
     },
     "node_modules/@gesslar/muddy": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@gesslar/muddy/-/muddy-2.2.2.tgz",
-      "integrity": "sha512-MfAatk6kPKFy6joN9IvyQ6x2Zp1ZrxelYdtKnoN+/W04HAzYvgykGsQdprWHJX3uBFVP7JnMnXrXndxhS7Y7MQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@gesslar/muddy/-/muddy-2.2.3.tgz",
+      "integrity": "sha512-n3zZromLSJZeGxGF1MZygep10h0Qr5nz+8OIUeKjzLOTs484UAgPf7RNvPt9JBvTcbBswYfYnFTApbTBKzOcDA==",
       "dev": true,
       "license": "0BSD",
       "dependencies": {
-        "@gesslar/actioneer": "^3.0.1",
+        "@gesslar/actioneer": "^3.1.1",
         "@gesslar/colours": "^1.0.0",
-        "@gesslar/toolkit": "^5.4.0",
+        "@gesslar/toolkit": "^5.6.0",
         "adm-zip": "^0.5.17",
-        "commander": "^14.0.3",
+        "commander": "^15.0.0",
         "xmlbuilder2": "^4.0.3"
       },
       "bin": {
@@ -81,14 +82,20 @@
         "node": ">=24"
       }
     },
-    "node_modules/@gesslar/muddy/node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+    "node_modules/@gesslar/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@gesslar/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-+u06w0Y3aiwD2gbHIfIOwlhWdJb2SlVsvJXvaLDZ1bCzPt5o5P+/6ZxEw54bcFSyhoBPOP+HaWXuRY8lTnPRrQ==",
       "dev": true,
-      "license": "MIT",
+      "license": "0BSD",
+      "dependencies": {
+        "@gesslar/toolkit": "^5.0.1",
+        "ajv": "^8.18.0",
+        "json5": "^2.2.3",
+        "yaml": "^2.8.3"
+      },
       "engines": {
-        "node": ">=20"
+        "node": ">=24.11.0"
       }
     },
     "node_modules/@gesslar/toolkit": {
@@ -106,44 +113,6 @@
       },
       "engines": {
         "node": ">=24"
-      }
-    },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/@oozcitak/dom": {
@@ -198,19 +167,6 @@
         "node": ">=20.0"
       }
     },
-    "node_modules/@sindresorhus/merge-streams": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/adm-zip": {
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
@@ -222,9 +178,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -245,50 +201,14 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/error-stack-parser": {
@@ -308,27 +228,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -341,143 +244,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fastq": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
-    "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/globby": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
-      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^2.1.0",
-        "fast-glob": "^3.3.3",
-        "ignore": "^7.0.3",
-        "path-type": "^6.0.0",
-        "slash": "^5.1.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
     },
     "node_modules/js-yaml": {
       "version": "4.2.0",
@@ -522,117 +288,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/path-type": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
-      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -641,54 +296,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
-    "node_modules/slash": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/stackframe": {
@@ -709,42 +316,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/unicorn-magic": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/xmlbuilder2": {

--- a/package.json
+++ b/package.json
@@ -1,18 +1,21 @@
 {
   "name": "glu",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A modular utility library for Mudlet that just works. No fuss, no muss.",
   "scripts": {
-    "build": "(\nset -e pipefail\nnpx @gesslar/muddy\nnpm run build:single\nnpm run build:min\n)",
+    "build": "(\nset -e pipefail\nnpx @gesslar/muddy\nnpm run build:single\nnpm run build:min\nnpm run build:docs\nnpm run build:lib\n)",
     "build:single": "python unify.py src/scripts build/Glu-single.lua",
     "build:min": "python unify.py src/scripts build/tmp/Glu-unified.lua && python mini.py build/tmp/Glu-unified.lua build/Glu-min.lua",
+    "build:docs": "npx bedoc --config bedoc/bedoc.yaml --sub docs",
+    "build:lib": "npx bedoc --config bedoc/bedoc.yaml --sub library",
     "clean": "rm -rf build/Glu-*.lua build/filtered build/tmp",
     "test": "docker run --rm -v \"$PWD\":/workspace gesslardev/mudlet-busted",
     "test:tree": "docker run --rm -e BUSTED_OUTPUT=treeOutput -v \"$PWD\":/workspace gesslardev/mudlet-busted",
     "docker:update": "docker pull gesslardev/mudlet-busted",
     "major": "npx @gesslar/muddy version major",
     "minor": "npx @gesslar/muddy version minor",
-    "patch": "npx @gesslar/muddy version patch"
+    "patch": "npx @gesslar/muddy version patch",
+    "update": "npx npm-check-updates -u && npm install"
   },
   "keywords": [
     "mudlet",
@@ -24,8 +27,9 @@
   },
   "license": "0BSD",
   "devDependencies": {
-    "@gesslar/bedoc": "^1.11.0",
-    "@gesslar/muddy": "^2.2.2"
+    "@gesslar/bedoc": "^2.1.3",
+    "@gesslar/muddy": "^2.2.3",
+    "@gesslar/toolkit": "^5.6.0"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR integrates BeDoc into the Glu build pipeline to generate Lua documentation (Markdown) and LuaLS type-definition stub files from the library's source. Resulting archives are attached to GitHub releases alongside the existing single and minified Lua files.

- Adds `bedoc/` with a Lua parser and two formatters (Markdown and LuaLS meta stubs), a BeDoc config, and a minimal `package.json` that marks the directory as ESM.
- Updates `package.json` to add `build:docs` / `build:lib` scripts and adds `@gesslar/toolkit` as an explicit root devDependency; updates `Release.yaml` to tar and upload the generated artifacts.

<h3>Confidence Score: 5/5</h3>

The change is additive — new build tooling, new action files, and minor workflow additions — with no modifications to the existing Lua library or release logic.

All changes are isolated to the new BeDoc pipeline. The formatter and parser logic handles optional fields defensively with null-coalescing and optional chaining. The workflow correctly uses @main for the reusable workflow call per repo convention. The bedoc/package.json intentionally carries no dependencies, relying on root node_modules for resolution, which is consistent with the root lock-file now including @gesslar/toolkit directly.

No files require special attention.

<sub>Reviews (5): Last reviewed commit: ["adding bedoc"](https://github.com/gesslar/glu/commit/53601cb61d57d13b0096ceead18553e0679c2f8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38878646)</sub>

<!-- /greptile_comment -->