### PR TITLE
Bump version to 2.0.3 and fix release artifact names

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -28,8 +28,8 @@ jobs:
         run: npm run build
       - name: Package docs + library
         run: |
-          tar -czf bedoc.docs.tar.gz -C build docs
-          tar -czf bedoc.library.tar.gz -C build library
+          tar -czf Glu.docs.tar.gz -C build docs
+          tar -czf Glu.library.tar.gz -C build library
       - name: Attach to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -38,4 +38,4 @@ jobs:
           gh release upload --clobber \
             "$version" \
             build/Glu-min.lua build/Glu-single.lua \
-            bedoc.docs.tar.gz bedoc.library.tar.gz
+            Glu.docs.tar.gz Glu.library.tar.gz

--- a/mfile
+++ b/mfile
@@ -1,7 +1,7 @@
 {
   "package": "Glu",
   "title": "Lua class library for Mudlet",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": "gesslar",
   "icon": "liquid-glue.png",
   "dependencies": "",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glu",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glu",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "0BSD",
       "devDependencies": {
         "@gesslar/bedoc": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glu",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A modular utility library for Mudlet that just works. No fuss, no muss.",
   "scripts": {
     "build": "(\nset -e pipefail\nnpx @gesslar/muddy\nnpm run build:single\nnpm run build:min\nnpm run build:docs\nnpm run build:lib\n)",


### PR DESCRIPTION
Bumps the version from `2.0.2` to `2.0.3` and corrects the release artifact names from `bedoc.*` to `glu.*` so that the packaged docs and library tarballs are correctly named upon release.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the package version from `2.0.2` to `2.0.3` and fixes a release workflow bug where artifact tarballs were created with `bedoc.*` names but uploaded under the same mismatched names, causing the release to reference non-existent files.

- Version is bumped consistently across `mfile`, `package.json`, and `package-lock.json`.
- Both the "Package docs + library" step and the "Attach to release" step in `Release.yaml` now use the correct `Glu.docs.tar.gz` and `Glu.library.tar.gz` names, so the upload will find the files it expects.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the artifact name mismatch that would have broken the release upload is fully corrected, and the version bump is consistent across all three manifest files.

Both halves of the artifact rename (creation and upload) are updated together, so the release workflow will now correctly produce and attach `Glu.docs.tar.gz` and `Glu.library.tar.gz`. The version bump is applied uniformly in `mfile`, `package.json`, and `package-lock.json`. No logic is changed beyond these two mechanical fixes.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["ugh"](https://github.com/gesslar/glu/commit/ae5de60ef86d9f1eb0ddf56232411cd13fb3bad0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38909825)</sub>

<!-- /greptile_comment -->